### PR TITLE
[IN-1028] Bruker risikererTrekk som sjekk på om trekk-beskjed 

### DIFF
--- a/src/__tests__/components/Melderkort.test.js
+++ b/src/__tests__/components/Melderkort.test.js
@@ -59,6 +59,7 @@ test('basic one Meldekort test no risk', () => {
     nyeMeldekort: {
       antallNyeMeldekort: 1,
       nesteMeldekort: {
+        datoForTrekk: 1533814941280,
         uke: 'week 42',
         kanSendesFra: 1531808013471,
         til: 1531808093471,
@@ -99,7 +100,7 @@ test('basic one Meldekort test no risk no remaining holidays', () => {
     nyeMeldekort: {
       antallNyeMeldekort: 1,
       nesteMeldekort: {
-        datoForTrekk: null,
+        datoForTrekk: 1531808093471,
         uke: 'week 42',
         kanSendesFra: 1531808013471,
         til: 1531808093471,
@@ -119,7 +120,7 @@ test('more than 13 Meldekort test no risk no remaining holidays', () => {
     nyeMeldekort: {
       antallNyeMeldekort: 13,
       nesteMeldekort: {
-        datoForTrekk: null,
+        datoForTrekk: 1531808093471,
         uke: 'week 42',
         kanSendesFra: 1531808013471,
         til: 1531808093471,
@@ -139,7 +140,7 @@ test('12 Meldekort test no risk no remaining holidays', () => {
     nyeMeldekort: {
       antallNyeMeldekort: 12,
       nesteMeldekort: {
-        datoForTrekk: null,
+        datoForTrekk: 1531808093471,
         uke: 'week 42',
         kanSendesFra: 1531808013471,
         til: 1531808093471,
@@ -180,6 +181,7 @@ test('nesteInnsendingAvMeldekort is null', () => {
     nyeMeldekort: {
       antallNyeMeldekort: 1,
       nesteMeldekort: {
+        datoForTrekk: 1533814941280,
         uke: 'week 42',
         kanSendesFra: 1531808013471,
         til: 1531808093471,

--- a/src/__tests__/components/__snapshots__/Melderkort.test.js.snap
+++ b/src/__tests__/components/__snapshots__/Melderkort.test.js.snap
@@ -26,6 +26,9 @@ exports[`12 Meldekort test no risk no remaining holidays 1`] = `
        
     </span>
     <span>
+      <span>
+        (Siste innsendingsfrist før trekk: 4. april 2019)
+      </span>
        
     </span>
     <span>
@@ -177,6 +180,9 @@ exports[`basic one Meldekort test no risk 1`] = `
        
     </span>
     <span>
+      <span>
+        (Siste innsendingsfrist før trekk: 4. april 2019)
+      </span>
        
     </span>
     <span>
@@ -224,6 +230,9 @@ exports[`basic one Meldekort test no risk no remaining holidays 1`] = `
        
     </span>
     <span>
+      <span>
+        (Siste innsendingsfrist før trekk: 4. april 2019)
+      </span>
        
     </span>
     <span>
@@ -302,6 +311,9 @@ exports[`more than 13 Meldekort test no risk no remaining holidays 1`] = `
        
     </span>
     <span>
+      <span>
+        (Siste innsendingsfrist før trekk: 4. april 2019)
+      </span>
        
     </span>
     <span>
@@ -342,6 +354,9 @@ exports[`nesteInnsendingAvMeldekort is null 1`] = `
        
     </span>
     <span>
+      <span>
+        (Siste innsendingsfrist før trekk: 4. april 2019)
+      </span>
        
     </span>
     <span>

--- a/src/js/components/Meldekort.js
+++ b/src/js/components/Meldekort.js
@@ -23,7 +23,7 @@ const melding = (next, count, formatDayAndMonth, numberToWord) => (next ? (
   />
 ) : null);
 
-const trekk = (risikererTrekk, formatDateMonth, next) => (next.sisteDatoForTrekk ? (<F id="meldekort.info.om.trekk" values={{ dato: formatDateMonth(next.sisteDatoForTrekk) }} />) : null);
+const trekk = (skalViseTrekkdato, formatDateMonth, next) => (skalViseTrekkdato ? (<F id="meldekort.info.om.trekk" values={{ dato: formatDateMonth(next.sisteDatoForTrekk) }} />) : null);
 
 class Meldekort extends Component {
   render() {
@@ -41,7 +41,7 @@ class Meldekort extends Component {
           <span className="texts">
             <span>{fremtidig(meldekort.nyeMeldekort, formatDateMonth)} </span>
             <span>{melding(meldekort.nyeMeldekort.nesteMeldekort, count, formatDayAndMonth, numberToWord)} </span>
-            <span>{trekk(risikererTrekk, formatDateMonth, meldekort.nyeMeldekort.nesteMeldekort)} </span>
+            <span>{trekk(!risikererTrekk, formatDateMonth, meldekort.nyeMeldekort.nesteMeldekort)} </span>
             <span>{advarsel(risikererTrekk)} </span>
             <p id="meldekort.lenkeTekst">{(count > 1 ? <F id="meldekort.se.oversikt" /> : <F id="meldekort.send" />)}</p>
             <p>{feriedager(meldekort)}</p>


### PR DESCRIPTION
Bruker risikererTrekk som sjekk på om trekk-beskjed skal vises i meldekort-boksen ettersom denne og count>1 (som er kravet for meldingen generelt) er hva man trenger for å avgjøre trekk-medlingen skal vises. 

Denne må sees i sammenheng med PR for IN-1028 i dittnav-api