### PR TITLE
[IN-1013] Setter riktig portnummer for backenden ved lokal kjøring.

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,9 @@
 PUBLIC_DITTNAV_API_URL=/dittnav/mock-api/new-person-info.json
 PUBLIC_SERVICES_URL=http://localhost:8080
 PUBLIC_LOGINSERVICE=/dittnav/login
+
+# Kjøring med lokal "ekte" backend
+# REACT_APP_DITT_NAV_BASE_API_URL=http://localhost:8085/person
+
+# Kjøring mot fake-login-service.
+REACT_APP_DITT_NAV_BASE_API_URL=http://localhost:9222

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ For å kjøre opp app-en i dev:
 7. terminal 8: `npm run start-proxy`
 8. gå til `http://localhost:9898/`
 
+For å gå mot lokalt kjørende backend:
+
+1. Kommenter ut URL-en til fake login server, og inn URL-en til backend, i `.env.development`
+2. `npm run start` 
+
 For å kjøre tester:
 
 1. `npm install`

--- a/src/js/Config.js
+++ b/src/js/Config.js
@@ -1,7 +1,7 @@
 const getDittNavBaseApiUrl = () => {
   const host = window.location.hostname;
   if (host.indexOf('localhost') > -1) {
-    return 'http://localhost:8085/person';
+    return process.env.REACT_APP_DITT_NAV_BASE_API_URL;
   }
   return `https://${window.location.hostname}/person`;
 };

--- a/src/js/Config.js
+++ b/src/js/Config.js
@@ -1,7 +1,7 @@
 const getDittNavBaseApiUrl = () => {
   const host = window.location.hostname;
   if (host.indexOf('localhost') > -1) {
-    return 'http://localhost:9222';
+    return 'http://localhost:8085/person';
   }
   return `https://${window.location.hostname}/person`;
 };
@@ -42,7 +42,7 @@ export default {
     SERVICES_URL: getServicesUrl(),
     LOGINSERVICE: getLoginUrl(),
     DITTNAV_API_URL: `${getDittNavBaseApiUrl()}/dittnav-api/person/personinfo`,
-    DITTNAV_API_PING_URL: `${getDittNavBaseApiUrl()}/dittnav-api/person/ping`,
+    DITTNAV_API_PING_URL: `${getDittNavBaseApiUrl()}/dittnav-api/ping`,
     REG_STATUS_LINK: 'https://nav.no/sbl/nav_security_check',
     CONTEXT_PATH: '/person/dittnav',
     ARBEIDSGIVER_LOGIN_URL: 'https://www.nav.no/no/Bedrift/Tjenester+og+skjemaer/NAV-+og+Altinn-tjenester',


### PR DESCRIPTION
 Appen skal nå kunne kjøres lokalt med backenden uten CORS-problematikk.