### PR TITLE
Feature/in 1040

### DIFF
--- a/src/__tests__/__snapshots__/App.test.js.snap
+++ b/src/__tests__/__snapshots__/App.test.js.snap
@@ -113,7 +113,7 @@ exports[`expect Login page rendering 1`] = `
             </p>
             <a
               className="lenke"
-              href="/person/dittnav/innlogget"
+              href="/person/dittnav"
             >
               <span>
                 Logg inn med ID-porten

--- a/src/__tests__/pages/__snapshots__/Login.test.js.snap
+++ b/src/__tests__/pages/__snapshots__/Login.test.js.snap
@@ -107,7 +107,7 @@ exports[`Login renders 1`] = `
         </p>
         <a
           className="lenke"
-          href="/person/dittnav/innlogget"
+          href="/person/dittnav"
         >
           <span>
             Logg inn med ID-porten

--- a/src/js/pages/Login.js
+++ b/src/js/pages/Login.js
@@ -8,7 +8,7 @@ const model = [
   { id: 'endagspassord-pensjon', url: conf.PSELV_LOGIN_LINK_URL, linkClassName: button },
   { id: 'endagspassord-ufore', url: conf.PSELV_LOGIN_LINK_UT_URL, linkClassName: button },
   { id: 'arbeidsgiver', url: conf.dittNav.ARBEIDSGIVER_LOGIN_URL, linkClassName: button },
-  { id: 'om', url: `${conf.dittNav.CONTEXT_PATH}/innlogget`, linkClassName: link },
+  { id: 'om', url: `${conf.dittNav.CONTEXT_PATH}`, linkClassName: link },
 ];
 
 class Login extends Component {


### PR DESCRIPTION
Fjernet /innlogget fra context-path i lenke til pålogging/pålogget side av dittnav (fra alternativ pålogging). Nå sendes man heller direkte til dittnav (og rederectes evt. til idporten)