### PR TITLE
Fiks styling på utloggingsknapp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8987,9 +8987,9 @@
       "integrity": "sha512-ELL5KKXaePsm9gBZUOJOr5rk5y6V/3VOL8XQF06u1EVS7LZdRO+p8yO1+eR6fL+oNvelQZoDEtm/rgQDF52Zqg=="
     },
     "nav-frontend-knapper-style": {
-      "version": "0.3.28",
-      "resolved": "https://registry.npmjs.org/nav-frontend-knapper-style/-/nav-frontend-knapper-style-0.3.28.tgz",
-      "integrity": "sha512-3afUuW8XYW4ncnANJcO4dRYFfJetAK6NVj99GTw6fFH0HpUYoNsx3oHSDhgUjUQtFxkXhzFnVgT27kZKodR1/A=="
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/nav-frontend-knapper-style/-/nav-frontend-knapper-style-0.3.31.tgz",
+      "integrity": "sha512-xHASg5ilK7vV+Dablaq6QG1Zzt3pQ95vXO+yRnYy0qEB3kjbGMinwmH/6aUcE5iUn51Yokz0PhwEdG35eczVuQ=="
     },
     "nav-frontend-lenkepanel": {
       "version": "1.0.30",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "nav-frontend-ikoner-assets": "^1.0.2",
     "nav-frontend-js-utils": "^1.0.7",
     "nav-frontend-knapper": "^1.0.33",
-    "nav-frontend-knapper-style": "^0.3.28",
+    "nav-frontend-knapper-style": "^0.3.31",
     "nav-frontend-lenkepanel": "^1.0.30",
     "nav-frontend-lenkepanel-style": "^0.3.25",
     "nav-frontend-lenker": "^1.0.27",

--- a/src/less/components/Hendelser.less
+++ b/src/less/components/Hendelser.less
@@ -12,8 +12,3 @@
   padding: 2rem;
   display: flex;
 }
-
-// Overstyrer .knapp fra designsystemet og dekoratøren.
-.Knapp {
-  min-height: 1.25rem ;
-}

--- a/src/less/components/Hendelser.less
+++ b/src/less/components/Hendelser.less
@@ -12,3 +12,8 @@
   padding: 2rem;
   display: flex;
 }
+
+// Overstyrer .knapp fra designsystemet og dekoratøren.
+.Knapp {
+  min-height: 1.25rem ;
+}

--- a/src/less/index.less
+++ b/src/less/index.less
@@ -84,5 +84,5 @@ body {
 // Overstyrer stylingen på knapp i dekoratøren, slik at det ikke oppstår feil i stylingen når man bruker knapper
 // fra designsystemet.
 .btn-logout {
-  min-height: 1.25rem;
+  min-height: 1.25rem !important;
 }

--- a/src/less/index.less
+++ b/src/less/index.less
@@ -81,7 +81,8 @@ body {
   margin-top: 1em;
 }
 
-// Overstyrer .knapp fra designsystemet som gir feil styling i dekoratøren.
-.knapp {
+// Overstyrer stylingen på knapp i dekoratøren, slik at det ikke oppstår feil i stylingen når man bruker knapper
+// fra designsystemet.
+.btn-logout {
   min-height: 1.25rem;
 }

--- a/src/less/index.less
+++ b/src/less/index.less
@@ -83,5 +83,5 @@ body {
 
 // Overstyrer .knapp fra designsystemet som gir feil styling i dekoratøren.
 .knapp {
-  min-height: 1.25rem ;
+  min-height: 1.25rem;
 }

--- a/src/less/index.less
+++ b/src/less/index.less
@@ -10,6 +10,7 @@
 @import '../../node_modules/nav-frontend-alertstriper-style/src/index.less';
 @import '../../node_modules/nav-frontend-chevron-style/src/index.less';
 @import '../../node_modules/nav-frontend-skjema-style/src/index.less';
+@import '../../node_modules/nav-frontend-knapper-style/src/index.less';
 
 @main-content-max-width: 640px;
 @mobile-breakpoint: 576px;
@@ -78,4 +79,9 @@ body {
 .header-spinner {
   width: 100%;
   margin-top: 1em;
+}
+
+// Overstyrer .knapp fra designsystemet som gir feil styling i dekoratøren.
+.knapp {
+  min-height: 1.25rem ;
 }


### PR DESCRIPTION
Overstyrer stylingen til .knapp slik at den ikke viser feil min-height i dekoratøren. Problemet skyldes sannsynligvis at den nye versjonen av knapper-style (0.3.31) gir feil styling av knappen i dekoratøren. 