### PR TITLE
Feature/pb 240 fjerne lenke til dinprofil

### DIFF
--- a/src/__tests__/pages/Home.test.js
+++ b/src/__tests__/pages/Home.test.js
@@ -14,7 +14,8 @@ it('render Home page without props', () => {
 
   const mininnboks = [];
   const sakstema = {
-    antallSaker: 0,
+    sakstemaList: [],
+    antallSakstema: 0,
   };
 
   const fetching = 4;

--- a/src/__tests__/pages/__snapshots__/Home.test.js.snap
+++ b/src/__tests__/pages/__snapshots__/Home.test.js.snap
@@ -168,17 +168,6 @@ exports[`render Home page without props 1`] = `
             <a
               className="lenke relatert-informasjon__link"
               data-ga="Dittnav/Lenkeliste"
-              href="http://localhost:9222/brukerprofil/"
-            >
-              Din profil
-            </a>
-          </div>
-          <div
-            className="relatert-informasjon__link-container"
-          >
-            <a
-              className="lenke relatert-informasjon__link"
-              data-ga="Dittnav/Lenkeliste"
               href="http://localhost:9222/veiledearbeidssoker/mistet-jobben/registrering"
             >
               Registrer deg som arbeidssøker

--- a/src/js/Config.js
+++ b/src/js/Config.js
@@ -68,7 +68,6 @@ const lenker = {
   uforetrygd: { tittel: 'Uføretrygd', url: `${getServicesUrl()}/pselv/publisering/uforetrygd.jsf?context=ut` },
   dineForeldrepenger: { tittel: 'Dine foreldrepenger', url: 'https://foreldrepenger.nav.no' },
   aktivitetsplan: { tittel: 'Aktivitetsplan', url: `${getServicesUrl()}/aktivitetsplan/` },
-  dinProfil: { tittel: 'Din profil', url: `${getServicesUrl()}/brukerprofil/` },
   personopplysninger: { tittel: 'Personopplysninger', url: `${getNavUrl()}/person/personopplysninger` },
   skjemaer: { tittel: 'Skjemaer', url: `${getNavUrl()}/soknader` },
   dinPensjon: { tittel: 'Din pensjon', url: `${getServicesUrl()}/pselv/publisering/dinpensjon.jsf` },
@@ -88,7 +87,6 @@ const generelleLenker = [
   lenker.uforetrygd,
   lenker.dineForeldrepenger,
   lenker.aktivitetsplan,
-  lenker.dinProfil,
   lenker.registrerDegSomArbeidssoker,
   lenker.dineStillingssok,
   lenker.personopplysninger,
@@ -100,7 +98,6 @@ const oppfolgingsLenker = [
   lenker.dineForeldrepenger,
   lenker.dinPensjon,
   lenker.uforetrygd,
-  lenker.dinProfil,
   lenker.personopplysninger,
 ];
 


### PR DESCRIPTION
Under relaterte lenker på Ditt NAV kan vi nå fjerne lenken Din profil, siden den nå er redirect til Personopplysninger. Personopplysninger skal beholdes som lenke.