### PR TITLE
Grooming/pb 281 rename melding

### DIFF
--- a/local.js
+++ b/local.js
@@ -28,7 +28,10 @@ app.get('/dittnav-legacy-api/saker/sakstema', (req, res) => res.sendFile(path.re
 app.get('/person/dittnav/api/feature', (req, res) => res.sendFile(path.resolve(__dirname, './mock-data/unleash.json')));
 app.get('/dittnav-api/brukernotifikasjoner', (req, res) => res.sendFile(path.resolve(__dirname, './mock-data/events.json')));
 app.post('/dittnav-event-test-producer/produce/informasjon', (req, res) => res.send('Done-eventer er produsert for alle identen: {ident} sine brukernotifikasjoner.'));
-app.post('/dittnav-event-test-producer/produce/done/all', (req, res) => res.send('Event ble opprettet'));
+app.post('/dittnav-event-test-producer/produce/oppgave', (req, res) => res.send('Et oppgave-event for identen: $userIdent har blitt lagt på kafka.'));
+app.post('/dittnav-event-test-producer/produce/innboks', (req, res) => res.send('Et innboks-event for identen: $userIdent har blitt lagt på kafka.'));
+app.post('/dittnav-event-test-producer/produce/done/all', (req, res) => res.send('Done-eventer er produsert for alle identen: {ident} sine brukernotifikasjoner.'));
+app.post('/dittnav-event-test-producer/produce/done', (req, res) => res.send('Done-event er produsert for identen: $userIdent sitt event med eventID: {doneDto.eventId}.'));
 
 app.use(bundler.middleware());
 

--- a/mock-data/events.json
+++ b/mock-data/events.json
@@ -72,7 +72,7 @@
 
   {
     "aktiv": true,
-    "type": "MELDING",
+    "type": "INNBOKS",
     "aktorId": "123",
     "dokumentId": "1001562939454499",
     "eventId": "1562939454499",

--- a/src/__tests__/components/meldinger/__snapshots__/Melderkort.test.js.snap
+++ b/src/__tests__/components/meldinger/__snapshots__/Melderkort.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`12 Meldekort test no risk no remaining holidays 1`] = `
 <a
-  className="lenkepanel infoMelding lenkepanel--border"
+  className="lenkepanel infomelding lenkepanel--border"
   href="http://localhost:9222/meldekort"
   onClick={null}
 >
@@ -97,7 +97,7 @@ exports[`Meldekort without next card test 1`] = `null`;
 
 exports[`basic Meldekort test 1`] = `
 <a
-  className="lenkepanel infoMelding lenkepanel--border"
+  className="lenkepanel infomelding lenkepanel--border"
   href="http://localhost:9222/meldekort"
   onClick={null}
 >
@@ -197,7 +197,7 @@ exports[`basic Meldekort test with no meldekort 1`] = `null`;
 
 exports[`basic one Meldekort test 1`] = `
 <a
-  className="lenkepanel infoMelding lenkepanel--border"
+  className="lenkepanel infomelding lenkepanel--border"
   href="http://localhost:9222/meldekort"
   onClick={null}
 >
@@ -295,7 +295,7 @@ exports[`basic one Meldekort test 1`] = `
 
 exports[`basic one Meldekort test no risk 1`] = `
 <a
-  className="lenkepanel infoMelding lenkepanel--border"
+  className="lenkepanel infomelding lenkepanel--border"
   href="http://localhost:9222/meldekort"
   onClick={null}
 >
@@ -391,7 +391,7 @@ exports[`basic one Meldekort test no risk 1`] = `
 
 exports[`basic one Meldekort test no risk no remaining holidays 1`] = `
 <a
-  className="lenkepanel infoMelding lenkepanel--border"
+  className="lenkepanel infomelding lenkepanel--border"
   href="http://localhost:9222/meldekort"
   onClick={null}
 >
@@ -484,7 +484,7 @@ exports[`basic one Meldekort test no risk no remaining holidays 1`] = `
 
 exports[`basic zero Meldekort test 1`] = `
 <a
-  className="lenkepanel infoMelding lenkepanel--border"
+  className="lenkepanel infomelding lenkepanel--border"
   href="http://localhost:9222/meldekort"
   onClick={null}
 >
@@ -566,7 +566,7 @@ exports[`basic zero Meldekort test 1`] = `
 
 exports[`more than 13 Meldekort test no risk no remaining holidays 1`] = `
 <a
-  className="lenkepanel infoMelding lenkepanel--border"
+  className="lenkepanel infomelding lenkepanel--border"
   href="http://localhost:9222/meldekort"
   onClick={null}
 >
@@ -659,7 +659,7 @@ exports[`more than 13 Meldekort test no risk no remaining holidays 1`] = `
 
 exports[`nesteInnsendingAvMeldekort is null 1`] = `
 <a
-  className="lenkepanel infoMelding lenkepanel--border"
+  className="lenkepanel infomelding lenkepanel--border"
   href="http://localhost:9222/meldekort"
   onClick={null}
 >
@@ -752,7 +752,7 @@ exports[`nesteInnsendingAvMeldekort is null 1`] = `
 
 exports[`no cards no risk 1`] = `
 <a
-  className="lenkepanel infoMelding lenkepanel--border"
+  className="lenkepanel infomelding lenkepanel--border"
   href="http://localhost:9222/meldekort"
   onClick={null}
 >

--- a/src/__tests__/components/meldinger/__snapshots__/MinInnboks.test.js.snap
+++ b/src/__tests__/components/meldinger/__snapshots__/MinInnboks.test.js.snap
@@ -8,7 +8,7 @@ exports[`MinInnboks with null input 1`] = `null`;
 
 exports[`MinInnboks with one document 1`] = `
 <a
-  className="lenkepanel infoMelding lenkepanel--border"
+  className="lenkepanel infomelding lenkepanel--border"
   href="https://tjenester-t6.nav.no/mininnboks"
   onClick={null}
 >
@@ -73,7 +73,7 @@ exports[`MinInnboks with one document 1`] = `
 
 exports[`MinInnboks with one task 1`] = `
 <a
-  className="lenkepanel infoMelding lenkepanel--border"
+  className="lenkepanel infomelding lenkepanel--border"
   href="https://tjenester-t6.nav.no/mininnboks"
   onClick={null}
 >
@@ -138,7 +138,7 @@ exports[`MinInnboks with one task 1`] = `
 
 exports[`MinInnboks with one unanswered 1`] = `
 <a
-  className="lenkepanel infoMelding lenkepanel--border"
+  className="lenkepanel infomelding lenkepanel--border"
   href="https://tjenester-t6.nav.no/mininnboks"
   onClick={null}
 >
@@ -204,7 +204,7 @@ exports[`MinInnboks with one unanswered 1`] = `
 exports[`MinInnboks with one unread task and one unread 1`] = `
 Array [
   <a
-    className="lenkepanel infoMelding lenkepanel--border"
+    className="lenkepanel infomelding lenkepanel--border"
     href="https://tjenester-t6.nav.no/mininnboks"
     onClick={null}
   >
@@ -266,7 +266,7 @@ Array [
     />
   </a>,
   <a
-    className="lenkepanel infoMelding lenkepanel--border"
+    className="lenkepanel infomelding lenkepanel--border"
     href="https://tjenester-t6.nav.no/mininnboks"
     onClick={null}
   >
@@ -332,7 +332,7 @@ Array [
 
 exports[`MinInnboks with two documents 1`] = `
 <a
-  className="lenkepanel infoMelding lenkepanel--border"
+  className="lenkepanel infomelding lenkepanel--border"
   href="https://tjenester-t6.nav.no/mininnboks"
   onClick={null}
 >
@@ -398,7 +398,7 @@ exports[`MinInnboks with two documents 1`] = `
 exports[`MinInnboks with two documents but different types 1`] = `
 Array [
   <a
-    className="lenkepanel infoMelding lenkepanel--border"
+    className="lenkepanel infomelding lenkepanel--border"
     href="https://tjenester-t6.nav.no/mininnboks"
     onClick={null}
   >
@@ -460,7 +460,7 @@ Array [
     />
   </a>,
   <a
-    className="lenkepanel infoMelding lenkepanel--border"
+    className="lenkepanel infomelding lenkepanel--border"
     href="https://tjenester-t6.nav.no/someother"
     onClick={null}
   >
@@ -526,7 +526,7 @@ Array [
 
 exports[`MinInnboks with two tasks 1`] = `
 <a
-  className="lenkepanel infoMelding lenkepanel--border"
+  className="lenkepanel infomelding lenkepanel--border"
   href="https://tjenester-t6.nav.no/mininnboks"
   onClick={null}
 >
@@ -591,7 +591,7 @@ exports[`MinInnboks with two tasks 1`] = `
 
 exports[`MinInnboks with two unanswered 1`] = `
 <a
-  className="lenkepanel infoMelding lenkepanel--border"
+  className="lenkepanel infomelding lenkepanel--border"
   href="https://tjenester-t6.nav.no/mininnboks"
   onClick={null}
 >
@@ -656,7 +656,7 @@ exports[`MinInnboks with two unanswered 1`] = `
 
 exports[`MinInnboks with two unread 1`] = `
 <a
-  className="lenkepanel infoMelding lenkepanel--border"
+  className="lenkepanel infomelding lenkepanel--border"
   href="https://tjenester-t6.nav.no/mininnboks"
   onClick={null}
 >
@@ -721,7 +721,7 @@ exports[`MinInnboks with two unread 1`] = `
 
 exports[`MinInnboks with zero tasks 1`] = `
 <a
-  className="lenkepanel infoMelding lenkepanel--border"
+  className="lenkepanel infomelding lenkepanel--border"
   href="https://tjenester-t6.nav.no/mininnboks"
   onClick={null}
 >

--- a/src/__tests__/components/meldinger/__snapshots__/PaabegynteSoknader.test.js.snap
+++ b/src/__tests__/components/meldinger/__snapshots__/PaabegynteSoknader.test.js.snap
@@ -6,7 +6,7 @@ exports[`PaabegynteSoknader green test 1`] = `null`;
 
 exports[`PaabegynteSoknader one soknad 1`] = `
 <a
-  className="lenkepanel infoMelding lenkepanel--border"
+  className="lenkepanel infomelding lenkepanel--border"
   href="http://nav.no"
   onClick={null}
 >
@@ -77,7 +77,7 @@ exports[`PaabegynteSoknader one soknad 1`] = `
 
 exports[`PaabegynteSoknader several soknader 1`] = `
 <a
-  className="lenkepanel infoMelding lenkepanel--border"
+  className="lenkepanel infomelding lenkepanel--border"
   href="https://tjenester-t6.nav.no/"
   onClick={null}
 >

--- a/src/__tests__/pages/__snapshots__/Home.test.js.snap
+++ b/src/__tests__/pages/__snapshots__/Home.test.js.snap
@@ -22,7 +22,7 @@ exports[`render Home page without props 1`] = `
           </span>
         </h1>
         <a
-          className="lenkepanel infoMelding lenkepanel--border"
+          className="lenkepanel infomelding lenkepanel--border"
           href="https://tjenester-t6.nav.no/"
           onClick={null}
         >

--- a/src/js/components/common/LenkepanelMedIkon.js
+++ b/src/js/components/common/LenkepanelMedIkon.js
@@ -77,7 +77,7 @@ const IkonInformasjon = () => (
   </svg>
 );
 
-const IkonMelding = () => (
+const IkonInnboks = () => (
   <svg width="48px" height="48px" viewBox="0 0 48 48" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink">
     <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
       <g transform="translate(-382.000000, -366.000000)">
@@ -124,5 +124,5 @@ const IkonBlyant = () => (
 );
 
 export {
-  LenkepanelMedIkon, IkonBlyant, IkonKane, IkonPille, IkonSkilt, IkonOppgave, IkonInformasjon, IkonMelding,
+  LenkepanelMedIkon, IkonBlyant, IkonKane, IkonPille, IkonSkilt, IkonOppgave, IkonInformasjon, IkonInnboks,
 };

--- a/src/js/components/meldinger/EtterregistreringMeldekort.js
+++ b/src/js/components/meldinger/EtterregistreringMeldekort.js
@@ -23,7 +23,7 @@ const EtterregistreringMeldekort = ({ ettereg, intl }) => {
   if (ettereg && ettereg.etterregistrerteMeldekort && ettereg.etterregistrerteMeldekort > 0) {
     return (
       <LenkepanelMedIkon
-        className="infoMelding"
+        className="infomelding"
         data-ga="Dittnav/Varsel"
         alt="Melding om etterregistrerte meldekort"
         overskrift={createOverskrift(ettereg, intl)}

--- a/src/js/components/meldinger/Hendelse.js
+++ b/src/js/components/meldinger/Hendelse.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import '../../../less/components/Hendelser.less';
 import PropTypes from 'prop-types';
-import { IkonInformasjon, IkonMelding, IkonOppgave, LenkepanelMedIkon } from '../common/LenkepanelMedIkon';
+import { IkonInformasjon, IkonInnboks, IkonOppgave, LenkepanelMedIkon } from '../common/LenkepanelMedIkon';
 import PanelMedIkon from '../common/PanelMedIkon';
 import PanelOverskrift from '../common/PanelOverskrift';
 
@@ -11,8 +11,8 @@ const getHendelseIkon = (type) => {
       return <IkonInformasjon />;
     case 'OPPGAVE':
       return <IkonOppgave />;
-    case 'MELDING':
-      return <IkonMelding />;
+    case 'INNBOKS':
+      return <IkonInnboks />;
     default:
       return null;
   }

--- a/src/js/components/meldinger/Hendelse.js
+++ b/src/js/components/meldinger/Hendelse.js
@@ -39,7 +39,7 @@ const Hendelse = ({ id, type, tekst, link, removeHendelse }) => {
           />
         ) : (
           <LenkepanelMedIkon
-            className="infoMelding"
+            className="infomelding"
             data-ga="Dittnav/Varsel"
             alt="Hendelse"
             overskrift={createOverskrift(tekst)}

--- a/src/js/components/meldinger/MinInnboks.js
+++ b/src/js/components/meldinger/MinInnboks.js
@@ -41,7 +41,7 @@ const MinInnboks = ({ mininnboks, intl }) => {
       {mininnboks && mininnboks.map(message => (
         <LenkepanelMedIkon
           key={message.type}
-          className="infoMelding"
+          className="infomelding"
           data-ga={`Dittnav/Varsel/${message.type.toLowerCase()} melding`}
           alt="Melding fra mininnboks"
           overskrift={createOverskrift(message, numberToWord, formatFlereEn)}

--- a/src/js/components/meldinger/MinInnboks.js
+++ b/src/js/components/meldinger/MinInnboks.js
@@ -2,17 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage as F, injectIntl, intlShape } from 'react-intl';
 import i18n from '../../../translations/i18n';
-import { IkonMelding, IkonOppgave, LenkepanelMedIkon } from '../common/LenkepanelMedIkon';
+import { IkonInnboks, IkonOppgave, LenkepanelMedIkon } from '../common/LenkepanelMedIkon';
 import PanelOverskrift from '../common/PanelOverskrift';
 
 const getMinInnboksIcon = (type) => {
   switch (type) {
     case 'DOKUMENT_VARSEL':
-      return <IkonMelding />;
+      return <IkonInnboks />;
     case 'OPPGAVE_VARSEL':
       return <IkonOppgave />;
     default:
-      return <IkonMelding />;
+      return <IkonInnboks />;
   }
 };
 

--- a/src/js/components/meldinger/PaabegynteSoknader.js
+++ b/src/js/components/meldinger/PaabegynteSoknader.js
@@ -20,7 +20,7 @@ const PaabegynteSoknader = ({ paabegynteSoknader, intl }) => {
 
   return (
     <LenkepanelMedIkon
-      className="infoMelding"
+      className="infomelding"
       data-ga="Dittnav/Varsel/Paabegynt soknad"
       alt="Melding om Søknader"
       overskrift={createOverskrift(paabegynteSoknader, soknadstekst, intl)}

--- a/src/js/components/meldinger/meldekort/Meldekort.js
+++ b/src/js/components/meldinger/meldekort/Meldekort.js
@@ -46,7 +46,7 @@ const Meldekort = ({ meldekort, intl }) => {
   if (antallNyeMeldekort > 0) {
     return (
       <LenkepanelMedIkon
-        className="infoMelding"
+        className="infomelding"
         data-ga="Dittnav/Varsel"
         alt="Melding om meldekort"
         overskrift={<PanelOverskrift overskrift={overskrift(true)} type="Element" />}
@@ -61,7 +61,7 @@ const Meldekort = ({ meldekort, intl }) => {
   if (meldekort.nyeMeldekort.nesteInnsendingAvMeldekort) {
     return (
       <LenkepanelMedIkon
-        className="infoMelding"
+        className="infomelding"
         data-ga="Dittnav/Varsel"
         alt="Melding om meldekort"
         overskrift={<PanelOverskrift overskrift={overskrift(false)} type="Element" />}

--- a/src/js/components/testgui/SelectTestGui.js
+++ b/src/js/components/testgui/SelectTestGui.js
@@ -11,7 +11,7 @@ const SelectTestGui = ({ setValg }) => {
     <Select label="Velg hendelse:" onChange={(e) => selectHendelse(e.target.value)}>
       <option value="informasjon">Informasjon</option>
       <option value="oppgave">Oppgave</option>
-      <option value="melding">Melding</option>
+      <option value="innboks">Innboks</option>
     </Select>
   );
 };

--- a/src/less/components/InfoMeldinger.less
+++ b/src/less/components/InfoMeldinger.less
@@ -5,27 +5,12 @@
   margin-left: 4.375rem;
   .blokk-xl();
 
-  .infoMelding {
+  .infomelding {
     margin-bottom: 1rem;
     padding: 0.75rem;
 
     .lenkepanel__innhold {
       padding: 0;
-    }
-  }
-
-  .meldekortpanel {
-    margin-bottom: 1rem;
-    padding: 0.75rem 0.75rem;
-    display: flex;
-
-    &__ikon {
-      align-self: center;
-    }
-
-    &__tekst {
-      align-self: center;
-      padding-left: 1rem;
     }
   }
 }


### PR DESCRIPTION
- Endrer `type` i svaret fra dittnav-api (melding -> innboks)
- Endrer kall mot `dittnav-event-test-producer` til å gå mot `/produce/innboks`