### PR TITLE
Fjerner kall mot index.js fil som ikke er i bruk

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -36,7 +36,6 @@
     <div class="pagewrapper">
         <div id="app"></div>
     </div>
-    <script src="../src/index.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Dette kallet leder til en fil som ikke er i bruk, og fører til et ekstra 404-kall i konsollen. I og med at vi bruker pus-dekoratøren skal vi uansett ikke bruke den slik.
