### PR TITLE
Fjerner source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "lint-es-fix": "eslint src/js/**/*.js src/__tests__/**/*.js --no-ignore --fix",
     "start": "react-scripts start",
     "build": "npm run build-less && npm run build-parcel && npm run build-lint",
-    "build-parcel": "rm -rf dist && parcel build public/index.html --public-url ./ --out-dir dist",
+    "build-parcel": "rm -rf dist && parcel build public/index.html --public-url ./ --out-dir dist --no-source-maps",
     "build-less": "lessc --npm-import=\"prefix=~\" src/less/index.less src/css/index.css",
     "build-lint": "npm run lint-es",
     "test": "react-scripts test --env=jsdom --coverage --watchAll=false",


### PR DESCRIPTION
Fjerner source maps for å redusere størrelsen på bygget av Dittnav. Nå bygges ikke lenger `*.js.map` og `*.css.map`. 