### PR TITLE
Fjerner unleash unleash midlertid, i påvente av vår egen provider

### DIFF
--- a/src/js/NavApp.js
+++ b/src/js/NavApp.js
@@ -5,7 +5,6 @@ import { IntlProvider, addLocaleData } from 'react-intl';
 import nb from 'react-intl/locale-data/nb';
 import en from 'react-intl/locale-data/en';
 import nn from 'react-intl/locale-data/nn';
-import FeatureTogglesProvider from './components/FeatureToggles';
 
 addLocaleData([...nb, ...en, ...nn]);
 

--- a/src/js/components/FeatureToggles.js
+++ b/src/js/components/FeatureToggles.js
@@ -1,6 +1,5 @@
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import Config from '../globalConfig';
 
 export const FeatureToggles = React.createContext({});
 
@@ -25,6 +24,10 @@ FeatureToggleWrapper.defaultProps = {
 };
 
 const FeatureTogglesProvider = ({ children }) => {
+  const loaded = false;
+  const featureToggles = {};
+  /*
+  TODO: Utkommentert i påvente av at vi skriver vår egen unleash-toggle-provider istedenfor å bruke Unleash gjennom pus-dekoratør.
   const [featureToggles, setFeatureToggles] = useState({});
   const [loaded, setLoaded] = useState(false);
 
@@ -36,7 +39,6 @@ const FeatureTogglesProvider = ({ children }) => {
       const togglePath = toggles.reduce((accumulatedToggles, currentToggle) => `${accumulatedToggles}&feature=${currentToggle}`);
       return `${Config.dittNav.CONTEXT_PATH}/api/feature?feature=${togglePath}`;
     };
-
     Promise.race([
       fetch(createURL(), { method: 'GET' })
         .then(r => r.json()),
@@ -51,6 +53,8 @@ const FeatureTogglesProvider = ({ children }) => {
       })
       .finally(() => setLoaded(true));
   }, []);
+
+   */
 
   if (loaded) {
     return (


### PR DESCRIPTION
Kommenterer ut fetching av feature-toggles fra Unleash. Vi skal skrive vår egen provider får dette. I påvente av at dette, PB-322, blir løst, feature-toggler vi med miljøvariabler istedenfor. 