### PR TITLE
Feature/pb 349 done events

### DIFF
--- a/local.js
+++ b/local.js
@@ -26,7 +26,6 @@ app.get('/dittnav-api/saker/paabegynte', (req, res) => res.sendFile(path.resolve
 app.get('/dittnav-api/meldinger/ubehandlede', (req, res) => res.sendFile(path.resolve(__dirname, './mock-data/ubehandlede.json')));
 app.get('/dittnav-api/saker/sakstema', (req, res) => res.sendFile(path.resolve(__dirname, './mock-data/sakstema.json')));
 app.get('/dittnav-api/brukernotifikasjoner', (req, res) => res.sendFile(path.resolve(__dirname, './mock-data/events.json')));
-
 app.post('/dittnav-api/produce/done', (req, res) => res.send('Done-event er sendt til handler for identen: {ident} sitt event med eventID: {eventId}.'));
 
 app.get('/person/dittnav/api/feature', (req, res) => res.sendFile(path.resolve(__dirname, './mock-data/unleash.json')));

--- a/local.js
+++ b/local.js
@@ -35,13 +35,14 @@ app.get('/dittnav-api/meldinger/ubehandlede', (req, res) => res.sendFile(path.re
 app.get('/dittnav-api/saker/sakstema', (req, res) => res.sendFile(path.resolve(__dirname, './mock-data/sakstema.json')));
 app.get('/dittnav-api/brukernotifikasjoner', (req, res) => res.sendFile(path.resolve(__dirname, './mock-data/events.json')));
 
+app.post('/dittnav-api/produce/done', (req, res) => res.send('Done-event er sendt til handler for identen: {ident} sitt event med eventID: {eventId}.'));
+
 app.get('/person/dittnav/api/feature', (req, res) => res.sendFile(path.resolve(__dirname, './mock-data/unleash.json')));
 
 app.post('/dittnav-event-test-producer/produce/beskjed', (req, res) => res.send('Done-eventer er produsert for alle identen: {ident} sine brukernotifikasjoner.'));
 app.post('/dittnav-event-test-producer/produce/oppgave', (req, res) => res.send('Et oppgave-event for identen: $userIdent har blitt lagt på kafka.'));
 app.post('/dittnav-event-test-producer/produce/innboks', (req, res) => res.send('Et innboks-event for identen: $userIdent har blitt lagt på kafka.'));
 app.post('/dittnav-event-test-producer/produce/done/all', (req, res) => res.send('Done-eventer er produsert for alle identen: {ident} sine brukernotifikasjoner.'));
-app.post('/dittnav-event-test-producer/produce/done', (req, res) => res.send('Done-event er produsert for identen: $userIdent sitt event med eventID: {doneDto.eventId}.'));
 
 app.use(bundler.middleware());
 

--- a/local.js
+++ b/local.js
@@ -16,15 +16,7 @@ const options = {}; // See options section of api docs, for the possibilities
 const bundler = new Bundler(file, options);
 
 // Let express use the bundler middleware, this will let Parcel handle every request over your express server
-
-app.use(cors({ origin: 'http://localhost:9002', credentials: true}));
-app.get('/dittnav-legacy-api/oppfolging', (req, res) => res.sendFile(path.resolve(__dirname, './mock-data/oppfolging.json')));
-app.get('/dittnav-legacy-api/meldekortinfo', (req, res) => res.sendFile(path.resolve(__dirname, './mock-data/meldekortinfo.json')));
-app.get('/dittnav-legacy-api/personalia/navn', (req, res) => res.sendFile(path.resolve(__dirname, './mock-data/person-navn.json')));
-app.get('/dittnav-legacy-api/personalia/ident', (req, res) => res.sendFile(path.resolve(__dirname, './mock-data/person-ident.json')));
-app.get('/dittnav-legacy-api/saker/paabegynte', (req, res) => res.sendFile(path.resolve(__dirname, './mock-data/paabegynte.json')));
-app.get('/dittnav-legacy-api/meldinger/ubehandlede', (req, res) => res.sendFile(path.resolve(__dirname, './mock-data/ubehandlede.json')));
-app.get('/dittnav-legacy-api/saker/sakstema', (req, res) => res.sendFile(path.resolve(__dirname, './mock-data/sakstema.json')));
+app.use(cors({ origin: 'http://localhost:9002', credentials: true }));
 
 app.get('/dittnav-api/oppfolging', (req, res) => res.sendFile(path.resolve(__dirname, './mock-data/oppfolging.json')));
 app.get('/dittnav-api/meldekortinfo', (req, res) => res.sendFile(path.resolve(__dirname, './mock-data/meldekortinfo.json')));
@@ -70,7 +62,7 @@ const shimproxy = () => {
               }
               return proxyResData;
             });
-        }
+        },
       }));
 
       proxy.listen(process.env.PORT, () => {

--- a/mock-data/events.json
+++ b/mock-data/events.json
@@ -1,33 +1,32 @@
 [
   {
-    "produsent": "DittNAV",
     "eventTidspunkt": "2019-11-27T17:51:26.001Z",
     "eventId": "1874877086001",
+    "uid": "937de6ce-f44f-47de-84d2-639ab2684627",
     "tekst": "Vi mottok søknaden din 18. september 2019. Du kan følge med på statusen i Dine foreldrepenger.",
     "link": "https://enNyLenke",
     "sistOppdatert": "2019-11-27T17:51:26.17575Z",
     "type": "BESKJED"
   },
   {
-    "produsent": "DittNAV",
     "eventTidspunkt": "2019-11-27T12:24:34.671Z",
     "eventId": "1174857474671",
+    "uid": "937de6ce-f84f-47de-84d2-639ad2684727",
     "tekst": "Vi mottok søknaden din 18. september 2019. Du kan følge med på statusen i Dine foreldrepenger.",
     "link": "",
     "sistOppdatert": "2019-11-27T12:24:35.014517Z",
     "type": "BESKJED"
   },
   {
-    "produsent": "DittNAV",
     "eventTidspunkt": "2019-11-27T12:24:34.671Z",
     "eventId": "1174857474672",
+    "uid": "934de6ce-f94f-47de-84d2-639ac2674627",
     "tekst": "Vi mottok søknaden din 28. september 2019. Du kan følge med på statusen i Dine foreldrepenger.",
     "link": null,
     "sistOppdatert": "2019-11-27T12:24:35.014517Z",
     "type": "BESKJED"
   },
   {
-    "produsent": "DittNAV",
     "eventTidspunkt": "2019-11-27T17:51:31.214Z",
     "eventId": "1674877091214",
     "tekst": "Du har en sykemelding som må godkjennes",
@@ -36,7 +35,6 @@
     "type": "OPPGAVE"
   },
   {
-    "produsent": "DittNAV",
     "eventTidspunkt": "2019-11-27T12:24:39.847Z",
     "eventId": "1274857479847",
     "tekst": "Oppgave: Mangelende dokumentasjon til søknad",
@@ -45,7 +43,6 @@
     "type": "OPPGAVE"
   },
   {
-    "produsent": "DittNAV",
     "eventTidspunkt": "2019-11-27T17:51:31.214Z",
     "eventId": "1574377091214",
     "tekst": "Svar fra veilederen din i innboksen: Hei, nå har jeg sjekket om...",
@@ -54,7 +51,6 @@
     "type": "INNBOKS"
   },
   {
-    "produsent": "DittNAV",
     "eventTidspunkt": "2019-11-27T12:24:39.847Z",
     "eventId": "1574857579847",
     "tekst": "Samtalereferat fra telefonsamtale 08.12.2019 kl. 11:44",

--- a/src/__tests__/pages/AktiveVarsler.test.js
+++ b/src/__tests__/pages/AktiveVarsler.test.js
@@ -11,9 +11,9 @@ test('AktiveVarsler empty', () => {
 test('AktiveVarsler one beskjed', () => {
   const hendelser = [
     {
-      produsent: 'DittNAV',
       eventTidspunkt: '2019-11-27T17:51:26.001Z',
       eventId: '1874877086001',
+      uid: '937de6ce-f44f-47de-84d2-639ab2684627',
       tekst: 'Vi mottok søknaden din 18. september 2019. Du kan følge med på statusen i Dine foreldrepenger.',
       link: 'https://enNyLenke',
       sistOppdatert: '2019-11-27T17:51:26.17575Z',
@@ -27,7 +27,6 @@ test('AktiveVarsler one beskjed', () => {
 test('AktiveVarsler one oppgave', () => {
   const hendelser = [
     {
-      produsent: 'DittNAV',
       eventTidspunkt: '2019-11-27T17:51:31.214Z',
       eventId: '1674877091214',
       tekst: 'Du har en sykemelding som må godkjennes',
@@ -43,7 +42,6 @@ test('AktiveVarsler one oppgave', () => {
 test('AktiveVarsler one innboks', () => {
   const hendelser = [
     {
-      produsent: 'DittNAV',
       eventTidspunkt: '2019-11-27T17:51:31.214Z',
       eventId: '1574377091214',
       tekst: 'Svar fra veilederen din i innboksen: Hei, nå har jeg sjekket om...',
@@ -59,16 +57,15 @@ test('AktiveVarsler one innboks', () => {
 test('AktiveVarsler several hendelser', () => {
   const hendelser = [
     {
-      produsent: 'DittNAV',
       eventTidspunkt: '2019-11-27T17:51:26.001Z',
       eventId: '1874877086001',
+      uid: '937de6ce-f44f-47de-84d2-639ab2684627',
       tekst: 'Vi mottok søknaden din 18. september 2019. Du kan følge med på statusen i Dine foreldrepenger.',
       link: 'https://enNyLenke',
       sistOppdatert: '2019-11-27T17:51:26.17575Z',
       type: 'BESKJED',
     },
     {
-      produsent: 'DittNAV',
       eventTidspunkt: '2019-11-27T17:51:31.214Z',
       eventId: '1674877091214',
       tekst: 'Du har en sykemelding som må godkjennes',
@@ -77,7 +74,6 @@ test('AktiveVarsler several hendelser', () => {
       type: 'OPPGAVE',
     },
     {
-      produsent: 'DittNAV',
       eventTidspunkt: '2019-11-27T17:51:31.214Z',
       eventId: '1574377091214',
       tekst: 'Svar fra veilederen din i innboksen: Hei, nå har jeg sjekket om...',

--- a/src/__tests__/pages/RenderVarslinger.test.js
+++ b/src/__tests__/pages/RenderVarslinger.test.js
@@ -30,16 +30,15 @@ it('expect Hendelser fetching', async () => {
     resolve(
       [
         {
-          produsent: 'DittNAV',
           eventTidspunkt: '2019-11-27T17:51:26.001Z',
           eventId: '1874877086001',
+          uid: '957de6ce-f44f-47de-84d2-639ab2684627',
           tekst: 'Vi mottok søknaden din 18. september 2019. Du kan følge med på statusen i Dine foreldrepenger.',
           link: 'https://enNyLenke',
           sistOppdatert: '2019-11-27T17:51:26.17575Z',
           type: 'BESKJED',
         },
         {
-          produsent: 'DittNAV',
           eventTidspunkt: '2019-11-27T17:51:31.214Z',
           eventId: '1674877091214',
           tekst: 'Du har en sykemelding som må godkjennes',
@@ -48,7 +47,6 @@ it('expect Hendelser fetching', async () => {
           type: 'OPPGAVE',
         },
         {
-          produsent: 'DittNAV',
           eventTidspunkt: '2019-11-27T17:51:31.214Z',
           eventId: '1574377091214',
           tekst: 'Svar fra veilederen din i innboksen: Hei, nå har jeg sjekket om...',

--- a/src/js/Api.js
+++ b/src/js/Api.js
@@ -58,6 +58,7 @@ const fetchSaker = () => fetchJSON(`${Config.dittNav.DITTNAV_SAKER_URL}`);
 const fetchMeldinger = () => fetchJSON(`${Config.dittNav.DITTNAV_MELDINGER_URL}`);
 const fetchSakstema = () => fetchJSON(Config.dittNav.DITTNAV_SAKSTEMA_URL);
 const fetchHendelser = () => fetchJSON(`${Config.dittNav.DITTNAV_HENDELSER_URL}`);
+const postDone = (content) => postJSON(`${Config.dittNav.DITTNAV_HENDELSER_URL}`, content);
 
 export default {
   checkAuth,
@@ -71,5 +72,6 @@ export default {
   fetchHendelser,
   fetchSakstema,
   postHendelser: postJSON,
+  postDone,
   redirectToLogin,
 };

--- a/src/js/Api.js
+++ b/src/js/Api.js
@@ -58,7 +58,10 @@ const fetchSaker = () => fetchJSON(`${Config.dittNav.DITTNAV_SAKER_URL}`);
 const fetchMeldinger = () => fetchJSON(`${Config.dittNav.DITTNAV_MELDINGER_URL}`);
 const fetchSakstema = () => fetchJSON(Config.dittNav.DITTNAV_SAKSTEMA_URL);
 const fetchHendelser = () => fetchJSON(`${Config.dittNav.DITTNAV_HENDELSER_URL}`);
-const postDone = (content) => postJSON(`${Config.dittNav.DITTNAV_HENDELSER_URL}`, content);
+
+const postHendelse = (path, content) => postJSON(`${Config.dittNav.EVENT_TEST_PRODUCER_URL}/${path}`, content);
+const postDoneAll = () => postJSON(`${Config.dittNav.EVENT_TEST_PRODUCER_DONE_ALL_URL}`, null);
+const postDone = (content) => postJSON(`${Config.dittNav.DITTNAV_DONE_URL}`, content);
 
 export default {
   checkAuth,
@@ -71,7 +74,8 @@ export default {
   fetchMeldinger,
   fetchHendelser,
   fetchSakstema,
-  postHendelser: postJSON,
+  postHendelse,
+  postDoneAll,
   postDone,
   redirectToLogin,
 };

--- a/src/js/components/meldinger/Hendelse.js
+++ b/src/js/components/meldinger/Hendelse.js
@@ -29,7 +29,7 @@ const createOverskrift = (tekst, erBeskjed) => {
   );
 };
 
-const Hendelse = ({ eventId, type, tekst, link, removeHendelse }) => {
+const Hendelse = ({ eventId, uid, type, tekst, link, removeHendelse }) => {
   const erBeskjed = type === 'BESKJED';
 
   return (
@@ -40,7 +40,7 @@ const Hendelse = ({ eventId, type, tekst, link, removeHendelse }) => {
             data-ga="Dittnav/Varsel"
             alt="Hendelse"
             overskrift={createOverskrift(tekst, erBeskjed)}
-            onClick={() => removeHendelse(eventId)}
+            onClick={() => removeHendelse(eventId, uid)}
             key={eventId}
             lenke={link}
             knapp
@@ -66,6 +66,7 @@ const Hendelse = ({ eventId, type, tekst, link, removeHendelse }) => {
 
 Hendelse.propTypes = {
   eventId: PropTypes.string.isRequired,
+  uid: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
   tekst: PropTypes.string.isRequired,
   link: PropTypes.string,

--- a/src/js/components/meldinger/Hendelse.js
+++ b/src/js/components/meldinger/Hendelse.js
@@ -41,7 +41,6 @@ const Hendelse = ({ eventId, uid, type, tekst, link, removeHendelse }) => {
             alt="Hendelse"
             overskrift={createOverskrift(tekst, erBeskjed)}
             onClick={() => removeHendelse(eventId, uid)}
-            key={eventId}
             lenke={link}
             knapp
           >
@@ -54,7 +53,6 @@ const Hendelse = ({ eventId, uid, type, tekst, link, removeHendelse }) => {
             alt="Hendelse"
             overskrift={createOverskrift(tekst)}
             href={link}
-            key={eventId}
           >
             {getHendelseIkon(type)}
           </LenkepanelMedIkon>
@@ -66,7 +64,7 @@ const Hendelse = ({ eventId, uid, type, tekst, link, removeHendelse }) => {
 
 Hendelse.propTypes = {
   eventId: PropTypes.string.isRequired,
-  uid: PropTypes.string.isRequired,
+  uid: PropTypes.string,
   type: PropTypes.string.isRequired,
   tekst: PropTypes.string.isRequired,
   link: PropTypes.string,
@@ -74,6 +72,7 @@ Hendelse.propTypes = {
 };
 
 Hendelse.defaultProps = {
+  uid: null,
   link: null,
 };
 

--- a/src/js/components/meldinger/Hendelser.js
+++ b/src/js/components/meldinger/Hendelser.js
@@ -9,14 +9,15 @@ import HendelserType from '../../types/HendelserType';
 const Hendelser = ({ hendelser }) => {
   const updateHendelser = useContext(HendelseContext);
 
-  const removeHendelse = (eventId) => {
+  const removeHendelse = (eventId, uid) => {
     updateHendelser(hendelser
       .filter(h => eventId !== h.eventId));
 
     Api.postHendelser(
-      `${Config.dittNav.EVENT_TEST_PRODUCER_URL}/produce/done`,
+      `${Config.dittNav.DITTNAV_DONE_URL}`,
       {
         eventId,
+        uid,
       },
     );
   };
@@ -27,6 +28,7 @@ const Hendelser = ({ hendelser }) => {
         <Hendelse
           key={h.eventId}
           eventId={h.eventId}
+          uid={h.uid}
           type={h.type}
           tekst={h.tekst}
           link={h.link}

--- a/src/js/components/meldinger/Hendelser.js
+++ b/src/js/components/meldinger/Hendelser.js
@@ -1,7 +1,5 @@
 import React, { useContext } from 'react';
 import Api from '../../Api';
-import '../../../less/components/Hendelser.less';
-import Config from '../../globalConfig';
 import Hendelse from './Hendelse';
 import HendelseContext from '../../context/HendelseContext';
 import HendelserType from '../../types/HendelserType';
@@ -13,13 +11,10 @@ const Hendelser = ({ hendelser }) => {
     updateHendelser(hendelser
       .filter(h => eventId !== h.eventId));
 
-    Api.postHendelser(
-      `${Config.dittNav.DITTNAV_DONE_URL}`,
-      {
-        eventId,
-        uid,
-      },
-    );
+    Api.postDone({
+      eventId,
+      uid,
+    });
   };
 
   return (
@@ -46,6 +41,5 @@ Hendelser.propTypes = {
 Hendelser.defaultProps = {
   hendelser: null,
 };
-
 
 export default Hendelser;

--- a/src/js/globalConfig.js
+++ b/src/js/globalConfig.js
@@ -57,6 +57,7 @@ export default {
     DITTNAV_DONE_URL: `${window.env.DITTNAV_API_URL}/produce/done`,
 
     EVENT_TEST_PRODUCER_URL: window.env.EVENT_TEST_PRODUCER_URL,
+    EVENT_TEST_PRODUCER_DONE_ALL_URL: `${window.env.EVENT_TEST_PRODUCER_URL}/produce/done/all`,
 
     CONTEXT_PATH: '/person/dittnav',
     ARBEIDSGIVER_LOGIN_URL: 'https://www.nav.no/no/Bedrift/Tjenester+og+skjemaer/NAV-+og+Altinn-tjenester',

--- a/src/js/globalConfig.js
+++ b/src/js/globalConfig.js
@@ -54,6 +54,8 @@ export default {
     DITTNAV_SAKSTEMA_URL: `${window.env.DITTNAV_API_URL}/saker/sakstema`,
 
     DITTNAV_HENDELSER_URL: `${window.env.DITTNAV_API_URL}/brukernotifikasjoner`,
+    DITTNAV_DONE_URL: `${window.env.DITTNAV_API_URL}/produce/done`,
+
     EVENT_TEST_PRODUCER_URL: window.env.EVENT_TEST_PRODUCER_URL,
 
     CONTEXT_PATH: '/person/dittnav',

--- a/src/js/pages/Hendelser/FormHendelser.js
+++ b/src/js/pages/Hendelser/FormHendelser.js
@@ -4,7 +4,6 @@ import { FormattedMessage as F } from 'react-intl';
 import React from 'react';
 import PropTypes from 'prop-types';
 import Api from '../../Api';
-import Config from '../../globalConfig';
 
 const FormHendelser = ({ tekst, lenke, valg, setTekst, setLenke, setHendelser }) => {
   const getHendelser = () => Api
@@ -15,8 +14,8 @@ const FormHendelser = ({ tekst, lenke, valg, setTekst, setLenke, setHendelser })
 
   const handleSubmit = (event) => {
     event.preventDefault();
-    Api.postHendelser(
-      `${Config.dittNav.EVENT_TEST_PRODUCER_URL}/produce/${valg}`,
+    Api.postHendelse(
+      `produce/${valg}`,
       {
         tekst,
         link: lenke,

--- a/src/js/pages/Hendelser/HendelserTestSide.js
+++ b/src/js/pages/Hendelser/HendelserTestSide.js
@@ -21,14 +21,15 @@ const HendelserTestSide = () => {
       null,
     );
 
-  const removeHendelse = (eventId) => {
+  const removeHendelse = (eventId, uid) => {
     setHendelser(hendelser
       .filter(h => eventId !== h.eventId));
 
     Api.postHendelser(
-      `${Config.dittNav.EVENT_TEST_PRODUCER_URL}/produce/done`,
+      `${Config.dittNav.DITTNAV_DONE_URL}`,
       {
         eventId,
+        uid,
       },
     );
   };
@@ -56,6 +57,7 @@ const HendelserTestSide = () => {
           {hendelser.map(h => (
             <Hendelse
               eventId={h.eventId}
+              uid={h.uid}
               type={h.type}
               tekst={h.tekst}
               link={h.link}

--- a/src/js/pages/Hendelser/HendelserTestSide.js
+++ b/src/js/pages/Hendelser/HendelserTestSide.js
@@ -3,7 +3,6 @@ import { FormattedMessage as F } from 'react-intl';
 import { Fareknapp } from 'nav-frontend-knapper';
 import { Panel } from 'nav-frontend-paneler';
 import Api from '../../Api';
-import Config from '../../globalConfig';
 import TittelHendelser from './TittelHendelser';
 import FormHendelser from './FormHendelser';
 import Hendelse from '../../components/meldinger/Hendelse';
@@ -16,22 +15,16 @@ const HendelserTestSide = () => {
   const [valg, setValg] = useState('beskjed');
 
   const removeHendelser = () => Api
-    .postHendelser(
-      `${Config.dittNav.EVENT_TEST_PRODUCER_URL}/produce/done/all`,
-      null,
-    );
+    .postDoneAll();
 
   const removeHendelse = (eventId, uid) => {
     setHendelser(hendelser
       .filter(h => eventId !== h.eventId));
 
-    Api.postHendelser(
-      `${Config.dittNav.DITTNAV_DONE_URL}`,
-      {
-        eventId,
-        uid,
-      },
-    );
+    Api.postDone({
+      eventId,
+      uid,
+    });
   };
 
   return (
@@ -56,6 +49,7 @@ const HendelserTestSide = () => {
         <div className="infomeldinger-list__container">
           {hendelser.map(h => (
             <Hendelse
+              key={h.eventId}
               eventId={h.eventId}
               uid={h.uid}
               type={h.type}


### PR DESCRIPTION
Bruker et nytt endepunkt i dittnav-api for å sende done-eventer (se PB-346). Justert koden etter endringer i svar fra `dittnav-api/brukernotifikasjoner`:
- Lagt til et uid felt for Beskjed
- Fjernet produsent feltet

feature/PB-349-done-events