### PR TITLE
Improvement/rydde types

### DIFF
--- a/src/js/components/InfoMeldinger.js
+++ b/src/js/components/InfoMeldinger.js
@@ -1,13 +1,16 @@
 import React from 'react';
 import { FormattedMessage as F } from 'react-intl';
-import PaabegynteSoknader, { PaabegynteSoknaderType } from './meldinger/PaabegynteSoknader';
-import Meldekort, { MeldekortType } from './meldinger/meldekort/Meldekort';
-import EtterregistreringMeldekort from './meldinger/EtterregistreringMeldekort';
-import MinInnboks, { MinInnboksType } from './meldinger/MinInnboks';
+import Config from '../globalConfig';
 import InformasjonsMeldinger from './meldinger/InformasjonsMeldinger';
+import PaabegynteSoknader from './meldinger/PaabegynteSoknader';
+import PaabegynteSoknaderType from '../types/PaabegynteSoknaderType';
+import Meldekort from './meldinger/meldekort/Meldekort';
+import MeldekortType from '../types/MeldekortType';
+import EtterregistreringMeldekort from './meldinger/EtterregistreringMeldekort';
+import MinInnboks from './meldinger/MinInnboks';
+import MinInnboksType from '../types/MinInnboksType';
 import Hendelser from './meldinger/Hendelser';
 import HendelserType from '../types/HendelserType';
-import Config from '../globalConfig';
 
 const InfoMeldinger = ({ meldekort, paabegynteSoknader, mininnboks, hendelser }) => {
   const isMeldeKortUser = meldekort ? meldekort.meldekortbruker : false;

--- a/src/js/components/meldinger/EtterregistreringMeldekort.js
+++ b/src/js/components/meldinger/EtterregistreringMeldekort.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { FormattedMessage as F, injectIntl, intlShape } from 'react-intl';
 import conf from '../../globalConfig';
 import i18n from '../../../translations/i18n';
 import LenkepanelMedIkon from '../common/LenkepanelMedIkon';
 import PanelOverskrift from '../common/PanelOverskrift';
 import IkonOppgave from '../../../assets/IkonOppgave';
+import MeldekortType from '../../types/MeldekortType';
 
 const tallordForMeldekort = (antallMeldekort, translater) => (antallMeldekort === 1 ? translater.oneNeuter() : translater.numberToWord(antallMeldekort));
 
@@ -37,9 +37,6 @@ const EtterregistreringMeldekort = ({ ettereg, intl }) => {
   return null;
 };
 
-export const MeldekortType = PropTypes.shape({
-  etterregistrerteMeldekort: PropTypes.number,
-});
 
 EtterregistreringMeldekort.propTypes = {
   ettereg: MeldekortType,

--- a/src/js/components/meldinger/MinInnboks.js
+++ b/src/js/components/meldinger/MinInnboks.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { FormattedMessage as F, injectIntl, intlShape } from 'react-intl';
 import i18n from '../../../translations/i18n';
 import LenkepanelMedIkon from '../common/LenkepanelMedIkon';
 import PanelOverskrift from '../common/PanelOverskrift';
 import IkonOppgave from '../../../assets/IkonOppgave';
 import IkonInnboks from '../../../assets/IkonInnboks';
+import MinInnboksType from '../../types/MinInnboksType';
 
 const getMinInnboksIcon = (type) => {
   switch (type) {
@@ -55,11 +55,6 @@ const MinInnboks = ({ mininnboks, intl }) => {
     </>
   );
 };
-
-export const MinInnboksType = PropTypes.arrayOf(PropTypes.shape({
-  type: PropTypes.string.isRequired,
-  url: PropTypes.string,
-}));
 
 MinInnboks.propTypes = {
   mininnboks: MinInnboksType,

--- a/src/js/components/meldinger/PaabegynteSoknader.js
+++ b/src/js/components/meldinger/PaabegynteSoknader.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { FormattedMessage as F, injectIntl, intlShape } from 'react-intl';
 import i18n from '../../../translations/i18n';
 import LenkepanelMedIkon from '../common/LenkepanelMedIkon';
 import PanelOverskrift from '../common/PanelOverskrift';
 import IkonBeskjed from '../../../assets/IkonBeskjed';
+import PaabegynteSoknaderType from '../../types/PaabegynteSoknaderType';
 
 const createOverskrift = (paabegynteSoknader, soknadstekst, intl) => (
   <PanelOverskrift
@@ -32,11 +32,6 @@ const PaabegynteSoknader = ({ paabegynteSoknader, intl }) => {
     </LenkepanelMedIkon>
   );
 };
-
-export const PaabegynteSoknaderType = PropTypes.shape({
-  url: PropTypes.string.isRequired,
-  antallPaabegynte: PropTypes.number.isRequired,
-});
 
 PaabegynteSoknader.propTypes = {
   intl: intlShape.isRequired, // eslint-disable-line react/no-typos

--- a/src/js/components/meldinger/meldekort/Meldekort.js
+++ b/src/js/components/meldinger/meldekort/Meldekort.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { FormattedMessage as F, injectIntl, intlShape } from 'react-intl';
-import PropTypes from 'prop-types';
 import conf from '../../../globalConfig';
 import i18n from '../../../../translations/i18n';
 import PanelOverskrift from '../../common/PanelOverskrift';
@@ -8,6 +7,7 @@ import LenkepanelMedIkon from '../../common/LenkepanelMedIkon';
 import { advarsel, feriedager, fremtidig, melding, trekk } from './Meldinger';
 import IkonBeskjed from '../../../../assets/IkonBeskjed';
 import IkonOppgave from '../../../../assets/IkonOppgave';
+import MeldekortType from '../../../types/MeldekortType';
 
 const Meldekort = ({ meldekort, intl }) => {
   if (!meldekort) {
@@ -76,27 +76,6 @@ const Meldekort = ({ meldekort, intl }) => {
   }
   return null;
 };
-
-const NesteMeldekortType = PropTypes.shape({
-  sisteDatoForTrekk: PropTypes.string,
-  risikererTrekk: PropTypes.bool,
-  uke: PropTypes.string,
-  kanSendesFra: PropTypes.string,
-  til: PropTypes.string,
-  fra: PropTypes.string,
-});
-
-const NyeMeldekortType = PropTypes.shape({
-  antallNyeMeldekort: PropTypes.number,
-  nesteInnsendingAvMeldekort: PropTypes.string,
-  nesteMeldekort: NesteMeldekortType,
-});
-
-export const MeldekortType = PropTypes.shape({
-  nyeMeldekort: NyeMeldekortType,
-  resterendeFeriedager: PropTypes.number,
-  etterregistrerteMeldekort: PropTypes.number,
-});
 
 Meldekort.propTypes = {
   meldekort: MeldekortType,

--- a/src/js/types/HendelserType.js
+++ b/src/js/types/HendelserType.js
@@ -1,7 +1,13 @@
 import PropTypes from 'prop-types';
 
 const HendelserType = PropTypes.arrayOf(
-  PropTypes.oneOfType([PropTypes.object]),
+  PropTypes.shape({
+    uid: PropTypes.string,
+    eventId: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
+    tekst: PropTypes.string.isRequired,
+    link: PropTypes.string,
+  }),
 );
 
 export default HendelserType;

--- a/src/js/types/MeldekortType.js
+++ b/src/js/types/MeldekortType.js
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types';
+
+const NesteMeldekortType = PropTypes.shape({
+  sisteDatoForTrekk: PropTypes.string,
+  risikererTrekk: PropTypes.bool,
+  uke: PropTypes.string,
+  kanSendesFra: PropTypes.string,
+  til: PropTypes.string,
+  fra: PropTypes.string,
+});
+
+const NyeMeldekortType = PropTypes.shape({
+  antallNyeMeldekort: PropTypes.number,
+  nesteInnsendingAvMeldekort: PropTypes.string,
+  nesteMeldekort: NesteMeldekortType,
+});
+
+const MeldekortType = PropTypes.shape({
+  nyeMeldekort: NyeMeldekortType,
+  resterendeFeriedager: PropTypes.number,
+  etterregistrerteMeldekort: PropTypes.number,
+});
+
+export default MeldekortType;

--- a/src/js/types/MinInnboksType.js
+++ b/src/js/types/MinInnboksType.js
@@ -1,0 +1,8 @@
+import PropTypes from 'prop-types';
+
+const MinInnboksType = PropTypes.arrayOf(PropTypes.shape({
+  type: PropTypes.string.isRequired,
+  url: PropTypes.string,
+}));
+
+export default MinInnboksType;

--- a/src/js/types/PaabegynteSoknaderType.js
+++ b/src/js/types/PaabegynteSoknaderType.js
@@ -1,0 +1,8 @@
+import PropTypes from 'prop-types';
+
+const PaabegynteSoknaderType = PropTypes.shape({
+  url: PropTypes.string.isRequired,
+  antallPaabegynte: PropTypes.number.isRequired,
+});
+
+export default PaabegynteSoknaderType;


### PR DESCRIPTION
- Sentraliserer egne Type deklarasjoner i /types slik at det blir lettere å lese komponentene.
- Presiserer typene til `HendelserType`.

improvement/rydde-types
