### PR TITLE
Sørger for at appen ikke spinner opp flere podder for tidlig

### DIFF
--- a/nais/nais.yaml
+++ b/nais/nais.yaml
@@ -31,4 +31,5 @@ spec:
       cpu: "3"
       memory: 768Mi
     requests:
+      cpu: 500m
       memory: 512Mi


### PR DESCRIPTION
Default på nais er at hvis gjennomsnittlig CPU-forbruk over alle nåværende podder er mer enn 50% (cpuThresholdPercentage) i 10 sekunder, så vil det spinnes opp en ny pod. Default request for CPU er 200m, dermed ville denne appen tidligere spinne opp nye podder med en gang snittforbruktet av CPU passerte 100m. Det er alt for lavt på disse appene når det er litt last.