### PR TITLE
Ingen hasing av content ved bygging med parcel

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "lint-es-fix": "eslint src/js/**/*.js src/__tests__/**/*.js --no-ignore --fix",
     "start": "react-scripts start",
     "build": "npm run build-less && npm run build-parcel && npm run build-lint",
-    "build-parcel": "rm -rf dist && parcel build public/index.html public/config.js --public-url ./ --out-dir dist --no-source-maps",
+    "build-parcel": "rm -rf dist && parcel build public/index.html public/config.js --public-url ./ --out-dir dist --no-source-maps --no-content-hash",
     "build-less": "lessc --npm-import=\"prefix=~\" src/less/index.less src/css/index.css",
     "build-lint": "npm run lint-es",
     "test": "react-scripts test --env=jsdom --modulePaths=src --coverage --watchAll=false",


### PR DESCRIPTION
Nye versjoner av DittNAV fikk en 404 feil ved deploy fordi filnavnet til `src.[hash].js` hadde endret seg. Dette begrenses noe ved at Parcel nå bare hasher på filnavn og ikke innhold, slik at `src.[hash].js` kun endrer seg hvis:

- Et filnavn endrer seg.
- Flere filer har samme navn.