### PR TITLE
Skjuler ok-knapp for alle beskjeder som har 'forskudd' i tesktfeltet

### DIFF
--- a/local/mock/beskjed.json
+++ b/local/mock/beskjed.json
@@ -12,7 +12,7 @@
     "eventTidspunkt": "2019-11-27T12:24:34.671Z",
     "eventId": "1174857474672",
     "uid": "934de6ce-f94f-47de-84d2-639ac2674627",
-    "tekst": "Vi har mottatt din søknad om pleiepenger. Hvis du er arbeidstaker må du ta kontakt med arbeidsgiver.",
+    "tekst": "Søknad om forskudd på dagpenger er mottatt.",
     "link": null,
     "sistOppdatert": "2019-11-27T12:24:35.014517Z",
     "sikkerhetsnivaa": 3

--- a/src/js/components/InfoMeldinger.js
+++ b/src/js/components/InfoMeldinger.js
@@ -22,12 +22,6 @@ const InfoMeldinger = ({ meldekort, paabegynteSoknader, mininnboks, innlogging, 
 
   return (
     <section className="infomeldinger-list">
-      <h1 className="skjermleser"><F id="dittnav.infomeldinger.varsler" /></h1>
-      <InformasjonsMeldinger isMeldeKortUser={isMeldeKortUser} />
-      {isMeldeKortUser ? <Meldekort meldekort={meldekort} /> : null}
-      <EtterregistreringMeldekort ettereg={meldekort} />
-      <PaabegynteSoknader paabegynteSoknader={paabegynteSoknader} />
-      <MinInnboks mininnboks={mininnboks} />
       {Config.HENDELSER_FEATURE_TOGGLE
         ? (
           <Brukernotifikasjoner
@@ -37,6 +31,12 @@ const InfoMeldinger = ({ meldekort, paabegynteSoknader, mininnboks, innlogging, 
             innlogging={innlogging}
           />
         ) : null}
+      <h1 className="skjermleser"><F id="dittnav.infomeldinger.varsler" /></h1>
+      <InformasjonsMeldinger isMeldeKortUser={isMeldeKortUser} />
+      {isMeldeKortUser ? <Meldekort meldekort={meldekort} /> : null}
+      <EtterregistreringMeldekort ettereg={meldekort} />
+      <PaabegynteSoknader paabegynteSoknader={paabegynteSoknader} />
+      <MinInnboks mininnboks={mininnboks} />
     </section>
   );
 };

--- a/src/js/components/brukernotifikasjoner/Beskjed.js
+++ b/src/js/components/brukernotifikasjoner/Beskjed.js
@@ -34,7 +34,8 @@ const Beskjed = ({ beskjed, innlogging, erAktiv, erInaktiv }) => {
   const overskrift = <PanelOverskrift overskrift={sikkerhetsnivaa.tekst} type="Normaltekst" />;
   const lenkeTekst = sikkerhetsnivaa.skalMaskeres ? 'beskjed.lenke.stepup.tekst' : 'beskjed.lenke.tekst';
 
-  const visKnapp = !(sikkerhetsnivaa.skalMaskeres || erInaktiv);
+  const visKnapp = !(sikkerhetsnivaa.skalMaskeres || erInaktiv)
+    && !beskjed.tekst.includes('forskudd');
 
   return (
     <PanelMedIkon


### PR DESCRIPTION
Slår av ok-knapp for alle beskjeder med tekst som inkluderer 'forskudd' i tekstfeltet.