### PR TITLE
Feature/rename varslinger

### DIFF
--- a/src/__tests__/pages/__snapshots__/AktiveVarsler.test.js.snap
+++ b/src/__tests__/pages/__snapshots__/AktiveVarsler.test.js.snap
@@ -233,7 +233,7 @@ exports[`AktiveVarsler several brukernotifikasjoner 1`] = `
       className="typo-systemtittel"
     >
       <span>
-        Du har 3 beskjeder fra NAV
+        Du har 3 beskjeder eller oppgaver fra NAV
       </span>
     </h2>
   </div>

--- a/src/__tests__/pages/__snapshots__/InaktiveVarsler.test.js.snap
+++ b/src/__tests__/pages/__snapshots__/InaktiveVarsler.test.js.snap
@@ -23,7 +23,7 @@ exports[`InaktiveVarsler one innboks 1`] = `
       className="typo-systemtittel"
     >
       <span>
-        Tidligere beskjeder
+        Tidligere Beskjeder og oppgaver
       </span>
     </h2>
   </div>
@@ -101,7 +101,7 @@ exports[`InaktiveVarsler one oppgave 1`] = `
       className="typo-systemtittel"
     >
       <span>
-        Tidligere beskjeder
+        Tidligere Beskjeder og oppgaver
       </span>
     </h2>
   </div>
@@ -179,7 +179,7 @@ exports[`InaktiveVarsler several brukernotifikasjoner 1`] = `
       className="typo-systemtittel"
     >
       <span>
-        Tidligere beskjeder
+        Tidligere Beskjeder og oppgaver
       </span>
     </h2>
   </div>

--- a/src/__tests__/pages/__snapshots__/InaktiveVarsler.test.js.snap
+++ b/src/__tests__/pages/__snapshots__/InaktiveVarsler.test.js.snap
@@ -23,7 +23,7 @@ exports[`InaktiveVarsler one innboks 1`] = `
       className="typo-systemtittel"
     >
       <span>
-        Tidligere Beskjeder og oppgaver
+        Tidligere beskjeder og oppgaver
       </span>
     </h2>
   </div>
@@ -101,7 +101,7 @@ exports[`InaktiveVarsler one oppgave 1`] = `
       className="typo-systemtittel"
     >
       <span>
-        Tidligere Beskjeder og oppgaver
+        Tidligere beskjeder og oppgaver
       </span>
     </h2>
   </div>
@@ -179,7 +179,7 @@ exports[`InaktiveVarsler several brukernotifikasjoner 1`] = `
       className="typo-systemtittel"
     >
       <span>
-        Tidligere Beskjeder og oppgaver
+        Tidligere beskjeder og oppgaver
       </span>
     </h2>
   </div>

--- a/src/__tests__/pages/__snapshots__/RenderVarslinger.test.js.snap
+++ b/src/__tests__/pages/__snapshots__/RenderVarslinger.test.js.snap
@@ -24,7 +24,7 @@ exports[`expect Brukernotifikasjoner fetching 1`] = `
               className="typo-sidetittel"
             >
               <span>
-                Beskjeder fra NAV
+                Beskjeder og oppgaver fra NAV
               </span>
             </h1>
           </div>

--- a/src/translations/nb.json
+++ b/src/translations/nb.json
@@ -46,7 +46,7 @@
   "varslinger.under.utvikling.ingress": "Her vil du kunne se alle tidligere meldinger fra NAV, men akkurat nå vises bare noen av beskjedene og oppgavene. Vi jobber med å forbedre siden og vil oppdatere den fortløpende. Du kan finne flere meldinger i {innboks} eller se informasjon om sakene dine i {saksoversikt}.",
   "varslinger.tittel": "Beskjeder og oppgaver fra NAV",
   "varslinger.aktive.tittel": "Du har {antall} beskjeder eller oppgaver fra NAV",
-  "varslinger.inaktive.tittel": "Tidligere Beskjeder og oppgaver",
+  "varslinger.inaktive.tittel": "Tidligere beskjeder og oppgaver",
   "varslinger.mininnboks.melding": "Finner du ikke meldingen du leter etter? Den ligger kanskje i {innboksen} din.",
 
   "fliser.ditt.sykevravaer": "Ditt sykefravær",

--- a/src/translations/nb.json
+++ b/src/translations/nb.json
@@ -44,9 +44,9 @@
 
   "varslinger.under.utvikling.tittel": "Denne siden er under utvikling",
   "varslinger.under.utvikling.ingress": "Her vil du kunne se alle tidligere meldinger fra NAV, men akkurat nå vises bare noen av meldingene. Vi jobber med å forbedre siden og vil oppdatere den fortløpende. Du kan finne flere meldinger i {innboks} eller se informasjon om sakene dine i {saksoversikt}.",
-  "varslinger.tittel": "Beskjeder fra NAV",
-  "varslinger.aktive.tittel": "Du har {antall} beskjeder fra NAV",
-  "varslinger.inaktive.tittel": "Tidligere beskjeder",
+  "varslinger.tittel": "Beskjeder og oppgaver fra NAV",
+  "varslinger.aktive.tittel": "Du har {antall} beskjeder eller oppgaver fra NAV",
+  "varslinger.inaktive.tittel": "Tidligere Beskjeder og oppgaver",
   "varslinger.mininnboks.melding": "Finner du ikke meldingen du leter etter? Den ligger kanskje i {innboksen} din.",
 
   "fliser.ditt.sykevravaer": "Ditt sykefravær",


### PR DESCRIPTION
Renamer Varslinger/Varsler til Beskjeder og/eller Oppgaver slik at det ikke forveksles med det som ligger i siden til Varselinnboks.