### PR TITLE
Feature/input validering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1320,6 +1320,11 @@
         "glob-to-regexp": "^0.3.0"
       }
     },
+    "@navikt/fnrvalidator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@navikt/fnrvalidator/-/fnrvalidator-1.1.0.tgz",
+      "integrity": "sha512-IJQymBSGmUYL79MENMlE/MCyE16X7QbPe5MVHz7x2eJDyiqhiCkAmDsVUTHE8Nqu1hmUHADk2qV98Frd/pHtbQ=="
+    },
     "@nodelib/fs.stat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
@@ -9832,9 +9837,9 @@
       "integrity": "sha512-yf9WUkhTxLYBFj29ZL3s5OuIbW9TfvUWIWoaP5ttyCkGMHzRiJParGWNR8QHLH6vkQEoyWFXmyWdtW7C9Qcs+Q=="
     },
     "nav-frontend-skjema": {
-      "version": "1.0.78",
-      "resolved": "https://registry.npmjs.org/nav-frontend-skjema/-/nav-frontend-skjema-1.0.78.tgz",
-      "integrity": "sha512-pmgt5aiWZ8lzIY09XSDi5Qty5+qgMSjo2+waMUIkdXIfFwSHpqoaLu4/skFBXcVvUQ+A+HSZZJba7SKXUwoOMw=="
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/nav-frontend-skjema/-/nav-frontend-skjema-2.0.13.tgz",
+      "integrity": "sha512-/B2xOqaY8VBGbF3BjcHtNH6rj4uRzNuvW/50JevP3OkmwvUqvu6XrlguEmuDzfxh+GDdnqyFCbyVFmyVYkWSlg=="
     },
     "nav-frontend-skjema-style": {
       "version": "1.0.48",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@babel/preset-env": "^7.7.1",
     "@babel/runtime-corejs2": "^7.7.2",
+    "@navikt/fnrvalidator": "^1.1.0",
     "classnames": "^2.2.6",
     "core-js": "^3.4.1",
     "cors": "^2.8.5",
@@ -42,7 +43,7 @@
     "nav-frontend-paneler-style": "^0.3.17",
     "nav-frontend-popover": "0.0.3",
     "nav-frontend-popover-style": "0.0.2",
-    "nav-frontend-skjema": "^1.0.78",
+    "nav-frontend-skjema": "^2.0.13",
     "nav-frontend-skjema-style": "^1.0.48",
     "nav-frontend-spinner": "^1.0.20",
     "nav-frontend-spinner-style": "^0.2.5",

--- a/src/js/pages/Hendelser/FormHendelser.js
+++ b/src/js/pages/Hendelser/FormHendelser.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { func, string } from 'prop-types';
 import { FormattedMessage as F } from 'react-intl';
 import { Input } from 'nav-frontend-skjema';
@@ -9,6 +9,8 @@ import { ADD_BESKJEDER } from '../../types/Actions';
 
 const FormHendelser = ({ tekst, lenke, valg, setTekst, setLenke, setOppgaver, setInnbokser }) => {
   const { dispatch } = useBeskjedStore();
+  const [error, setError] = useState('');
+  const [disabled, setDisabled] = useState(false);
 
   const getBrukernotifikasjoner = () => {
     Api.fetchBeskjeder()
@@ -40,12 +42,23 @@ const FormHendelser = ({ tekst, lenke, valg, setTekst, setLenke, setOppgaver, se
     setLenke('');
   };
 
+  const handleTekstValidation = (event) => {
+    setTekst(event.target.value);
+
+    if (tekst.length > 500) {
+      setError('Maks lengde på teksten er 500 tegn');
+      setDisabled(true);
+    }
+  };
+
   return (
     <form onSubmit={handleSubmit}>
       <Input
         label="Skriv inn ny tekst:"
         value={tekst}
-        onChange={e => setTekst(e.target.value)}
+        onChange={e => handleTekstValidation(e)}
+        feil={error}
+        disabled={disabled}
       />
       <Input
         label="Skriv inn ny lenke:"

--- a/src/js/pages/Hendelser/FormHendelser.js
+++ b/src/js/pages/Hendelser/FormHendelser.js
@@ -62,7 +62,6 @@ const FormHendelser = ({ tekst, lenke, valg, setTekst, setLenke, setOppgaver, se
         value={tekst}
         onChange={e => handleTekstValidation(e)}
         feil={error}
-        disabled={disabled}
       />
       <Input
         label="Skriv inn ny lenke:"

--- a/src/js/pages/Hendelser/FormHendelser.js
+++ b/src/js/pages/Hendelser/FormHendelser.js
@@ -29,6 +29,11 @@ const FormHendelser = ({ tekst, lenke, valg, setTekst, setLenke, setOppgaver, se
       });
   };
 
+  const clearInput = () => {
+    setTekst('');
+    setLenke('');
+  };
+
   const handleSubmit = (event) => {
     event.preventDefault();
     Api.postHendelse(
@@ -38,14 +43,13 @@ const FormHendelser = ({ tekst, lenke, valg, setTekst, setLenke, setOppgaver, se
         link: lenke,
       },
     );
-    setTekst('');
-    setLenke('');
+    clearInput();
   };
 
   const handleTekstValidation = (event) => {
     setTekst(event.target.value);
 
-    if (tekst.length > 500) {
+    if (tekst.length > 500 - 2) {
       setError('Maks lengde på teksten er 500 tegn');
       setDisabled(true);
     }
@@ -66,7 +70,7 @@ const FormHendelser = ({ tekst, lenke, valg, setTekst, setLenke, setOppgaver, se
         onChange={e => setLenke(e.target.value)}
       />
       <div className="knapper">
-        <Knapp className="knapper__send" htmlType="submit">
+        <Knapp className="knapper__send" htmlType="submit" disabled={disabled}>
           <F id="hendelser.send" />
         </Knapp>
         <Knapp className="knapper__hent" htmlType="button" onClick={() => getBrukernotifikasjoner()}>


### PR DESCRIPTION
Nå valideres tekstfeltet slik at det ikke kan sendes inn eventer med mer enn 500 tegn. Knappen for å sende inn eventer slås av hvis teksten er større enn 500 tegn.

- Bumper nav-frontend-skjema til 2.0.13.