### PR TITLE
Bruker shallow renderer for å teste asynkrone kall

### DIFF
--- a/src/__tests__/pages/RenderVarslinger.test.js
+++ b/src/__tests__/pages/RenderVarslinger.test.js
@@ -2,8 +2,8 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import RenderVarslinger from 'js/pages/Varslinger/RenderVarslinger';
 import wrapIntl from 'js/IntlTestHelper';
+import ShallowRenderer from 'react-test-renderer/shallow';
 import BeskjedStoreProvider from '../../js/context/BeskjedStoreProvider';
-const ReactTestRenderer = require('react-test-renderer');
 
 const mockApi = () => (
   {
@@ -104,12 +104,17 @@ it('expect Brukernotifikasjoner fetching', async () => {
     });
   });
 
-  const component = ReactTestRenderer.create(wrapIntl(
+
+  const renderer = new ShallowRenderer();
+
+  renderer.render(wrapIntl(
     <BeskjedStoreProvider>
       <RenderVarslinger api={api} />
     </BeskjedStoreProvider>,
   ));
+
+  const component = renderer.getRenderOutput();
   await flushPromises();
 
-  expect(component.toJSON()).toMatchSnapshot();
+  expect(component).toMatchSnapshot();
 });

--- a/src/__tests__/pages/__snapshots__/RenderVarslinger.test.js.snap
+++ b/src/__tests__/pages/__snapshots__/RenderVarslinger.test.js.snap
@@ -1,143 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`expect Brukernotifikasjoner fetching 1`] = `
-<main
-  role="main"
+<BeskjedStoreProvider
+  beskjeder={null}
+  inaktiveBeskjeder={null}
 >
-  <div
-    className="container"
-  >
-    <div
-      className="row"
-    >
-      <div
-        className="maincontent side-innhold"
-      >
-        <div
-          className="col-md-12"
-          id="dittnav-main-container"
-        >
-          <div
-            className="varslinger-tittel"
-          >
-            <h1
-              className="typo-sidetittel"
-            >
-              <span>
-                Beskjeder og oppgaver fra NAV
-              </span>
-            </h1>
-          </div>
-          <section
-            className="infomeldinger-list"
-          >
-            <div
-              className="alertbox"
-            >
-              <div
-                className="alertstripe infomelding alertstripe--advarsel"
-              >
-                <span
-                  className="alertstripe__ikon"
-                >
-                  <span
-                    className="sr-only"
-                  >
-                    advarsel
-                  </span>
-                  <svg
-                    focusable="false"
-                    height="1.5em"
-                    kind="advarsel-sirkel-fyll"
-                    viewBox="0 0 24 24"
-                    width="1.5em"
-                  >
-                    <g
-                      fill="none"
-                      fillRule="evenodd"
-                    >
-                      <path
-                        d="M12.205-.004l-.214.002a12.225 12.225 0 0 0-8.517 3.659C1.179 5.977-.053 9.013.002 12.208c.115 6.613 5.296 11.793 11.795 11.793l.212-.002c6.726-.116 12.105-5.595 11.99-12.21C23.883 5.178 18.702-.003 12.204-.003z"
-                        fill="#FFA733"
-                        fillRule="nonzero"
-                      />
-                      <path
-                        d="M12.027 19H12A1.499 1.499 0 0 1 11.973 16L12 16a1.501 1.501 0 0 1 .027 3z"
-                        fill="#3E3832"
-                      />
-                      <path
-                        d="M12 5a1 1 0 0 1 1 1v7a1 1 0 0 1-2 0V6a1 1 0 0 1 1-1z"
-                        fill="#3E3832"
-                        fillRule="nonzero"
-                      />
-                    </g>
-                  </svg>
-                </span>
-                <div
-                  className="typo-normal alertstripe__tekst"
-                >
-                  <h2
-                    className="typo-undertittel"
-                  >
-                    <span>
-                      Denne siden er under utvikling
-                    </span>
-                  </h2>
-                  <p
-                    className="typo-normal"
-                  >
-                    <span>
-                      Her vil du kunne se alle tidligere meldinger fra NAV, men akkurat nå vises bare noen av beskjedene og oppgavene. Vi jobber med å forbedre siden og vil oppdatere den fortløpende. Du kan finne flere meldinger i 
-                      <a
-                        className="lenke"
-                        href="http://localhost:9222/mininnboks"
-                        id="alert-lenke-id"
-                      >
-                        innboksen
-                      </a>
-                       eller se informasjon om sakene dine i 
-                      <a
-                        className="lenke"
-                        href="http://localhost:9222/saksoversikt"
-                        id="alert-lenke-id"
-                      >
-                        Dine saker
-                      </a>
-                      .
-                    </span>
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              className="aktive-varsler"
-            />
-            <div
-              className="inaktive-varsler"
-            />
-            <div
-              className="panel mininnboks-panel"
-            >
-              <p
-                className="typo-normal"
-              >
-                <span>
-                  Finner du ikke meldingen du leter etter? Den ligger kanskje i 
-                  <a
-                    className="lenke"
-                    href="http://localhost:9222/mininnboks"
-                    id="innboksmelding-id"
-                  >
-                    innboksen
-                  </a>
-                   din.
-                </span>
-              </p>
-            </div>
-          </section>
-        </div>
-      </div>
-    </div>
-  </div>
-</main>
+  <VarslingerRender
+    api={
+      Object {
+        "fetchBeskjeder": [Function],
+        "fetchInaktiveBeskjeder": [Function],
+        "fetchInaktiveInnbokser": [Function],
+        "fetchInaktiveOppgaver": [Function],
+        "fetchInnbokser": [Function],
+        "fetchInnlogging": [Function],
+        "fetchOppgaver": [Function],
+      }
+    }
+  />
+</BeskjedStoreProvider>
 `;


### PR DESCRIPTION
I forbindelse med PB-312 brukes `ShallowRenderer` for å teste asynkrone kall fordi det ellers ga en forskjellig snapshot i den nye pipelinen.