### PR TITLE
Viser tid i tillegg til dato for brukernotifikasjoner

### DIFF
--- a/src/__tests__/components/__snapshots__/Brukernotifikasjoner.test.js.snap
+++ b/src/__tests__/components/__snapshots__/Brukernotifikasjoner.test.js.snap
@@ -63,7 +63,7 @@ Array [
         <p
           className="typo-undertekst lenkepanel__etikett"
         >
-          13.03.2020
+          13.03.2020 - 09:53
         </p>
       </div>
     </div>
@@ -128,7 +128,7 @@ Array [
         <p
           className="typo-undertekst lenkepanel__etikett"
         >
-          13.03.2020
+          13.03.2020 - 09:53
         </p>
       </div>
     </div>
@@ -193,7 +193,7 @@ Array [
         <p
           className="typo-undertekst lenkepanel__etikett"
         >
-          13.03.2020
+          13.03.2020 - 09:53
         </p>
       </div>
     </div>
@@ -258,7 +258,7 @@ Array [
         <p
           className="typo-undertekst lenkepanel__etikett"
         >
-          13.03.2020
+          13.03.2020 - 09:53
         </p>
       </div>
     </div>
@@ -330,7 +330,7 @@ Array [
         <p
           className="typo-undertekst lenkepanel__etikett"
         >
-          13.03.2020
+          13.03.2020 - 09:53
         </p>
       </div>
     </div>
@@ -395,7 +395,7 @@ Array [
         <p
           className="typo-undertekst lenkepanel__etikett"
         >
-          13.03.2020
+          13.03.2020 - 09:53
         </p>
       </div>
     </div>
@@ -465,7 +465,7 @@ Array [
         <p
           className="typo-undertekst lenkepanel__etikett"
         >
-          13.03.2020
+          13.03.2020 - 09:53
         </p>
       </div>
     </div>
@@ -530,7 +530,7 @@ Array [
         <p
           className="typo-undertekst lenkepanel__etikett"
         >
-          13.03.2020
+          13.03.2020 - 09:53
         </p>
       </div>
     </div>

--- a/src/__tests__/components/brukernotifikasjoner/__snapshots__/Beskjed.test.js.snap
+++ b/src/__tests__/components/brukernotifikasjoner/__snapshots__/Beskjed.test.js.snap
@@ -58,7 +58,7 @@ exports[`Beskjed with empty link 1`] = `
     <p
       className="typo-undertekst beskjed__etikett"
     >
-      13.03.2020
+      13.03.2020 - 09:53
     </p>
   </div>
   <div
@@ -144,7 +144,7 @@ exports[`Beskjed with link 1`] = `
     <p
       className="typo-undertekst beskjed__etikett"
     >
-      13.03.2020
+      13.03.2020 - 09:53
     </p>
   </div>
   <div
@@ -222,7 +222,7 @@ exports[`Beskjed with null as link 1`] = `
     <p
       className="typo-undertekst beskjed__etikett"
     >
-      13.03.2020
+      13.03.2020 - 09:53
     </p>
   </div>
   <div
@@ -308,7 +308,7 @@ exports[`Beskjed with sikkerhetsnivaa 3 and innloggingsnivaa 3 1`] = `
     <p
       className="typo-undertekst beskjed__etikett"
     >
-      13.03.2020
+      13.03.2020 - 09:53
     </p>
   </div>
   <div
@@ -394,7 +394,7 @@ exports[`Beskjed with sikkerhetsnivaa 3 and innloggingsnivaa 4 1`] = `
     <p
       className="typo-undertekst beskjed__etikett"
     >
-      13.03.2020
+      13.03.2020 - 09:53
     </p>
   </div>
   <div
@@ -482,7 +482,7 @@ exports[`Beskjed with sikkerhetsnivaa 4 and innloggingsnivaa 3 1`] = `
     <p
       className="typo-undertekst beskjed__etikett"
     >
-      13.03.2020
+      13.03.2020 - 09:53
     </p>
   </div>
 </div>
@@ -554,7 +554,7 @@ exports[`Beskjed with sikkerhetsnivaa 4 and innloggingsnivaa 4 1`] = `
     <p
       className="typo-undertekst beskjed__etikett"
     >
-      13.03.2020
+      13.03.2020 - 09:53
     </p>
   </div>
   <div

--- a/src/__tests__/components/brukernotifikasjoner/__snapshots__/Innboks.test.js.snap
+++ b/src/__tests__/components/brukernotifikasjoner/__snapshots__/Innboks.test.js.snap
@@ -58,7 +58,7 @@ exports[`Innboks with sikkerhetsnivaa 3 and innloggingsnivaa 3 1`] = `
       <p
         className="typo-undertekst lenkepanel__etikett"
       >
-        13.03.2020
+        13.03.2020 - 09:53
       </p>
     </div>
   </div>
@@ -126,7 +126,7 @@ exports[`Innboks with sikkerhetsnivaa 3 and innloggingsnivaa 4 1`] = `
       <p
         className="typo-undertekst lenkepanel__etikett"
       >
-        13.03.2020
+        13.03.2020 - 09:53
       </p>
     </div>
   </div>
@@ -196,7 +196,7 @@ exports[`Innboks with sikkerhetsnivaa 4 and innloggingsnivaa 3 1`] = `
       <p
         className="typo-undertekst lenkepanel__etikett"
       >
-        13.03.2020
+        13.03.2020 - 09:53
       </p>
     </div>
   </div>
@@ -264,7 +264,7 @@ exports[`Innboks with sikkerhetsnivaa 4 and innloggingsnivaa 4 1`] = `
       <p
         className="typo-undertekst lenkepanel__etikett"
       >
-        13.03.2020
+        13.03.2020 - 09:53
       </p>
     </div>
   </div>

--- a/src/__tests__/components/brukernotifikasjoner/__snapshots__/Oppgave.test.js.snap
+++ b/src/__tests__/components/brukernotifikasjoner/__snapshots__/Oppgave.test.js.snap
@@ -58,7 +58,7 @@ exports[`Oppgave with sikkerhetsnivaa 3 and innloggingsnivaa 3 1`] = `
       <p
         className="typo-undertekst lenkepanel__etikett"
       >
-        13.03.2020
+        13.03.2020 - 09:53
       </p>
     </div>
   </div>
@@ -126,7 +126,7 @@ exports[`Oppgave with sikkerhetsnivaa 3 and innloggingsnivaa 4 1`] = `
       <p
         className="typo-undertekst lenkepanel__etikett"
       >
-        13.03.2020
+        13.03.2020 - 09:53
       </p>
     </div>
   </div>
@@ -196,7 +196,7 @@ exports[`Oppgave with sikkerhetsnivaa 4 and innloggingsnivaa 3 1`] = `
       <p
         className="typo-undertekst lenkepanel__etikett"
       >
-        13.03.2020
+        13.03.2020 - 09:53
       </p>
     </div>
   </div>
@@ -264,7 +264,7 @@ exports[`Oppgave with sikkerhetsnivaa 4 and innloggingsnivaa 4 1`] = `
       <p
         className="typo-undertekst lenkepanel__etikett"
       >
-        13.03.2020
+        13.03.2020 - 09:53
       </p>
     </div>
   </div>

--- a/src/__tests__/pages/__snapshots__/AktiveVarsler.test.js.snap
+++ b/src/__tests__/pages/__snapshots__/AktiveVarsler.test.js.snap
@@ -75,7 +75,7 @@ exports[`AktiveVarsler one beskjed 1`] = `
       <p
         className="typo-undertekst beskjed__etikett"
       >
-        13.03.2020
+        13.03.2020 - 09:53
       </p>
     </div>
     <div
@@ -157,7 +157,7 @@ exports[`AktiveVarsler one innboks 1`] = `
         <p
           className="typo-undertekst lenkepanel__etikett"
         >
-          13.03.2020
+          13.03.2020 - 09:53
         </p>
       </div>
     </div>
@@ -229,7 +229,7 @@ exports[`AktiveVarsler one oppgave 1`] = `
         <p
           className="typo-undertekst lenkepanel__etikett"
         >
-          13.03.2020
+          13.03.2020 - 09:53
         </p>
       </div>
     </div>
@@ -312,7 +312,7 @@ exports[`AktiveVarsler several brukernotifikasjoner 1`] = `
         <p
           className="typo-undertekst lenkepanel__etikett"
         >
-          13.03.2020
+          13.03.2020 - 09:53
         </p>
       </div>
     </div>
@@ -385,7 +385,7 @@ exports[`AktiveVarsler several brukernotifikasjoner 1`] = `
       <p
         className="typo-undertekst beskjed__etikett"
       >
-        13.03.2020
+        13.03.2020 - 09:53
       </p>
     </div>
     <div
@@ -460,7 +460,7 @@ exports[`AktiveVarsler several brukernotifikasjoner 1`] = `
         <p
           className="typo-undertekst lenkepanel__etikett"
         >
-          13.03.2020
+          13.03.2020 - 09:53
         </p>
       </div>
     </div>

--- a/src/__tests__/pages/__snapshots__/InaktiveVarsler.test.js.snap
+++ b/src/__tests__/pages/__snapshots__/InaktiveVarsler.test.js.snap
@@ -84,7 +84,7 @@ exports[`InaktiveVarsler one innboks 1`] = `
         <p
           className="typo-undertekst lenkepanel__etikett"
         >
-          13.03.2020
+          13.03.2020 - 09:53
         </p>
       </div>
     </div>
@@ -167,7 +167,7 @@ exports[`InaktiveVarsler one oppgave 1`] = `
         <p
           className="typo-undertekst lenkepanel__etikett"
         >
-          13.03.2020
+          13.03.2020 - 09:53
         </p>
       </div>
     </div>
@@ -250,7 +250,7 @@ exports[`InaktiveVarsler several brukernotifikasjoner 1`] = `
         <p
           className="typo-undertekst lenkepanel__etikett"
         >
-          13.03.2020
+          13.03.2020 - 09:53
         </p>
       </div>
     </div>
@@ -315,7 +315,7 @@ exports[`InaktiveVarsler several brukernotifikasjoner 1`] = `
         <p
           className="typo-undertekst lenkepanel__etikett"
         >
-          13.03.2020
+          13.03.2020 - 09:53
         </p>
       </div>
     </div>

--- a/src/js/utils/DatoUtils.js
+++ b/src/js/utils/DatoUtils.js
@@ -7,8 +7,7 @@ const transformTolokalDatoTid = (tidspunkt) => {
 
   return moment(tidspunkt)
     .local()
-    .format('DD-MM-YYYY')
-    .replace(/-/g, '.');
+    .format('DD.MM.YYYY - HH:mm');
 };
 
 export default transformTolokalDatoTid;


### PR DESCRIPTION
Viser tid i tillegg til dato for brukernotifikasjoner på formatet: `'DD.MM.YYYY - HH:mm'`