### PR TITLE
Nyere versjoner av pus-decorator fra githubs package registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM navikt/common:0.1 AS navikt-common
-FROM navikt/pus-decorator
+FROM docker.pkg.github.com/navikt/pus-decorator/pus-decorator
 
 ENV APPLICATION_NAME=dittnav
 ENV CONTEXT_PATH=person/dittnav

--- a/src/js/globalConfig.js
+++ b/src/js/globalConfig.js
@@ -148,7 +148,6 @@ export default {
   PSELV_LOGIN_LINK_URL: '/pselv/tilleggsfunksjonalitet/innlogging.jsf',
   PSELV_LOGIN_LINK_UT_URL: '/pselv/tilleggsfunksjonalitet/innlogging.jsf?context=ut',
   LENKER: lenker,
-  HENDELSER_FEATURE_TOGGLE: window.env.HENDELSER_FEATURE_TOGGLE === 'true',
   VARSLINGER_FEATURE_TOGGLE: window.env.VARSLINGER_FEATURE_TOGGLE === 'true',
   TEST_SIDE_FEATURE_TOGGLE: window.env.TEST_SIDE_FEATURE_TOGGLE === 'true',
 


### PR DESCRIPTION
Henter inn nyere versjoner av `pus-decorator` fra package registry, bl.a med en bumpet versjon av `no.nav.common` biblioteket.