### PR TITLE
Fix/pb 324 sideveis scrolling

### DIFF
--- a/src/less/index.less
+++ b/src/less/index.less
@@ -55,8 +55,15 @@
 
 @import './legacy-decorator';
 
+html, body {
+  height: 100%;
+}
+
 body {
   background: @navLysGra !important;
+  min-height: 100%;
+  width: 100%;
+  overflow-x: hidden;
 }
 
 .underline {


### PR DESCRIPTION
Historikk-siden med den nye dekoratøren ga brukere mulighet til å scrolle sideveis i mobilvisningen. Siden dette ga en for lang header i forhold til siden, fjernes muligheten til scrolle sideveis.

PB-324. Header problem i historikksiden på mobil (sideveis scrollemulighet).