### PR TITLE
Koronaspesial høyde-fiks

### DIFF
--- a/src/less/components/KoronaSpesial.less
+++ b/src/less/components/KoronaSpesial.less
@@ -4,7 +4,6 @@
 .col-setup(@cols, @margins) {
   flex-grow: 1;
   flex-shrink: 0;
-  flex-basis: calc(percentage(1 / (@cols + 1)) + 1px);
   max-width: calc(percentage(1 / @cols) - (@margins - @margins / @cols));
 
   &:not(:nth-child(@{cols}n)) {
@@ -21,12 +20,12 @@
   max-height: 0;
   overflow: hidden;
   visibility: hidden;
-  padding: 3px;
   transition: max-height 0.5s ease-out;
 
   &--loaded {
-    max-height: 20rem;
+    max-height: 30rem;
     visibility: visible;
+    overflow: visible;
   }
 
   & > * {


### PR DESCRIPTION
- Øker max-høyde for å hindre at boksen kuttes på smale skjermer.
- Fjerner noe overflødig css.