### PR TITLE
Fjerner ubrukt lenke-styling fra den gamle dekoratøren

### DIFF
--- a/src/less/pagewrapper.less
+++ b/src/less/pagewrapper.less
@@ -77,18 +77,6 @@ input, select {
     font-size: 100%;
 }
 
-.lenke-fremhevet, .side-innhold a:not(.knapp) {
-  border-bottom: 1px solid #b7b1a9;
-}
-
-.lenke-fremhevet:hover, .side-innhold a:not(.knapp):hover {
-  border-bottom-color: #0067c5;
-}
-
-.lenke-fremhevet:active, .side-innhold a:not(.knapp):active {
-  border-bottom-color: #634689;
-}
-
 svg:not(:root) {
   overflow: hidden;
 }


### PR DESCRIPTION
Noe av stylingen som fjernes førte til at paneler og lenkepaneler fikk en lysegrå bottom-border istedenfor svart.

* Fikser også visningen av lenker i microfrontenden.