### PR TITLE
Tar i bruk x-token-expires-soon headeren

### DIFF
--- a/src/js/Api.js
+++ b/src/js/Api.js
@@ -5,10 +5,17 @@ const redirectToLogin = () => {
   window.location.assign(`${Config.dittNav.LOGINSERVICE}`);
 };
 
+const checkTokenExpiration = (headers) => {
+  if (headers.get('x-token-expires-soon')) {
+    redirectToLogin();
+  }
+};
+
 const fetchJSON = (url) => new Promise((res, rej) => {
   fetch(url, { method: 'GET', credentials: 'include' })
     .then(r => {
       if (r.ok) {
+        checkTokenExpiration(r.headers);
         return r.json();
       }
       rej(r);


### PR DESCRIPTION
Denne blir satt til true når det er to minutter til token-et utløpes og brukes for å unngå at vi ender opp med kall i dittnav-api som ikke rekker å fullføre før token-et utløper. I første omgang redirectes brukeren direkte til login, men vi kan også legge inn en modal etterhvert.