### PR TITLE
Pb 465 token veksling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,11 @@ const checkAuthThenRenderApp = () => {
         return;
       }
       if (e.status === 401) {
-        Api.redirectToLogin();
+        Api.fetchInnlogging()
+          .then((result) => {
+            Api.exchangeOpenAmTokenToOidc(result.securityLevel);
+          })
+          .catch(() => Api.redirectToLogin());
         return;
       }
       log(`Unexpected backend error, some page content may be unavailable: ${e}`);

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ const checkAuthThenRenderApp = () => {
       if (e.status === 401) {
         Api.fetchInnlogging()
           .then((result) => {
-            Api.exchangeOpenAmTokenToOidc(result.securityLevel);
+            Api.handleOpenAmToken(result.securityLevel);
           })
           .catch(() => Api.redirectToLogin());
         return;

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ const checkAuthThenRenderApp = () => {
       if (e.status === 401) {
         Api.fetchInnlogging()
           .then((result) => {
-            Api.handleOpenAmToken(result.securityLevel);
+            Api.exchangeOpenAmTokenToOidc(result.securityLevel);
           })
           .catch(() => Api.redirectToLogin());
         return;

--- a/src/js/Api.js
+++ b/src/js/Api.js
@@ -1,3 +1,4 @@
+import Cookies from 'js-cookie';
 import Config from './globalConfig';
 import log from './utils/Logger';
 
@@ -9,11 +10,19 @@ const redirectToLoginWithLevel4 = () => {
   window.location.assign(`${Config.dittNav.LOGINSERVICE_LEVEL_4}`);
 };
 
+const hasOpenAmToken = Cookies.get('nav-esso');
+
 const exchangeOpenAmTokenToOidc = (securityLevel) => {
   if (securityLevel === '4') {
     redirectToLoginWithLevel4();
   } else {
     redirectToLogin();
+  }
+};
+
+const handleOpenAmToken = (securityLevel) => {
+  if (hasOpenAmToken) {
+    exchangeOpenAmTokenToOidc(securityLevel);
   }
 };
 
@@ -165,4 +174,5 @@ export default {
   redirectToLogin,
   redirectToLoginWithLevel4,
   exchangeOpenAmTokenToOidc,
+  handleOpenAmToken,
 };

--- a/src/js/Api.js
+++ b/src/js/Api.js
@@ -5,6 +5,18 @@ const redirectToLogin = () => {
   window.location.assign(`${Config.dittNav.LOGINSERVICE}`);
 };
 
+const redirectToLoginWithLevel4 = () => {
+  window.location.assign(`${Config.dittNav.LOGINSERVICE_LEVEL_4}`);
+};
+
+const exchangeOpenAmTokenToOidc = (securityLevel) => {
+  if (securityLevel === '4') {
+    redirectToLoginWithLevel4();
+  } else {
+    redirectToLogin();
+  }
+};
+
 const checkTokenExpiration = (headers) => {
   if (headers.get('x-token-expires-soon')) {
     redirectToLogin();
@@ -151,4 +163,6 @@ export default {
   postDoneAll,
   postDone,
   redirectToLogin,
+  redirectToLoginWithLevel4,
+  exchangeOpenAmTokenToOidc,
 };

--- a/src/js/Api.js
+++ b/src/js/Api.js
@@ -1,4 +1,3 @@
-import Cookies from 'js-cookie';
 import Config from './globalConfig';
 import log from './utils/Logger';
 
@@ -10,19 +9,11 @@ const redirectToLoginWithLevel4 = () => {
   window.location.assign(`${Config.dittNav.LOGINSERVICE_LEVEL_4}`);
 };
 
-const hasOpenAmToken = Cookies.get('nav-esso');
-
 const exchangeOpenAmTokenToOidc = (securityLevel) => {
   if (securityLevel === '4') {
     redirectToLoginWithLevel4();
   } else {
     redirectToLogin();
-  }
-};
-
-const handleOpenAmToken = (securityLevel) => {
-  if (hasOpenAmToken) {
-    exchangeOpenAmTokenToOidc(securityLevel);
   }
 };
 
@@ -174,5 +165,4 @@ export default {
   redirectToLogin,
   redirectToLoginWithLevel4,
   exchangeOpenAmTokenToOidc,
-  handleOpenAmToken,
 };


### PR DESCRIPTION
Fikser veksling fra et openam-token til et oidc-token ved å sette riktig innlogginsnivå når man gjør en redirect til loginservice. Dette skal løse at:
-  brukere fikk feil sikkerhetsnivå fra innloggingslinje-api på grunn av race conditions 
- dittnav-api fikk et oidc-token med feil sikkerhetsnivå