### PR TITLE
Tekstendring i inngangen til oversiktssiden over din koronasituasjon

### DIFF
--- a/src/js/globalConfig.js
+++ b/src/js/globalConfig.js
@@ -84,7 +84,7 @@ const lenker = {
     url: `${window.env.NAVNO_URL}/no/nav-og-samfunn/om-nav/saksbehandlingstider-i-nav`,
   },
   koronaSituasjon: {
-    tittel: 'Din økonomiske situasjon i forbindelse med forskudd på dagpenger',
+    tittel: 'Fra 1.september starter vi å trekke forskudd på dagpenger',
     url: `${window.env.NAVNO_URL}/dagpenger/forskudd/oversikt`,
   },
   dineFullmakter: {

--- a/src/translations/nb.json
+++ b/src/translations/nb.json
@@ -2,7 +2,7 @@
   "korona.virus-varsel.ingress": "Se informasjon om rettighetene dine.",
   "korona.dagpenger-forskudd.ingress": "Koronasituasjonen gjør at det tar lengre tid å behandle søknaden din. Derfor kan du søke om forskudd.",
   "korona.behandlingstid.ingress": "Koronasituasjonen gjør at det tar lengre tid å behandle søknader. Les om endringene.",
-  "korona.din.situasjon.ingress": "Du kan her se en oversiktsside for dine forskudd. Her vil du se hvor mye du har mottatt i forskudd, når du kan søke om eventuelt nytt forskudd.",
+  "korona.din.situasjon.ingress": "Her er oversiktssiden som viser deg mottatt beløp, restbeløp, informasjon om nedbetaling og frister for å søke om nytt forskudd.",
 
   "dittnav.infomeldinger.varsler": "Varsler",
   "dittnav.infomeldinger.inngang.varslinger": "Se tidligere beskjeder og oppgaver",


### PR DESCRIPTION
I forbindelse med at forskuddsutbetalinger skal trekkes fra dagpengeutbetalinger fra 1. september, endres teksten i lenkepanelet som går til din koronasituasjon.