### PR TITLE
Remove/q6 template

### DIFF
--- a/nais/dev-sbs/q6.json
+++ b/nais/dev-sbs/q6.json
@@ -1,9 +1,0 @@
-{
-  "namespace": "q6",
-  "ingresses": [
-    "https://dittnav-q6.nais.oera-q.local",
-    "https://dittnav-q6.dev-sbs.nais.io",
-    "https://www-q6.nav.no/person/dittnav",
-    "https://tjenester-q6.nav.no/person/dittnav"
-  ]
-}

--- a/nais/nais.yaml
+++ b/nais/nais.yaml
@@ -22,7 +22,7 @@ spec:
     enabled: true
     path: person/dittnav/internal/metrics
   readiness:
-    path: person/dittnav/internal/isAlive
+    path: person/dittnav/internal/isReady
     port: 8080
     initialDelay: 10
   replicas:


### PR DESCRIPTION
* Sletter nais-template for q6.
* Bruker isReady for å sjekke readiness. Denne ble endret til isAlive for å få deploy-et ut appen til q6, men det er ikke lenger nødvendig.