### PR TITLE
Fiks baseUrl til /produce/done sendt fra en beskjed

### DIFF
--- a/src/js/Api.js
+++ b/src/js/Api.js
@@ -126,7 +126,7 @@ const postDoneAll = () => (
 );
 
 const postDone = (content) => (
-  postJSON(`${TestProducer.DONE_URL}`, content)
+  postJSON(`${Dittnav.DONE_URL}`, content)
 );
 
 export default {


### PR DESCRIPTION
Fiks baseUrl til /produce/done sendt fra en beskjed. Denne skal gå mot dittnav-api og ikke testproducer-en.