### PR TITLE
Service-redirects slik at appen kan flyttes til team-namespace

### DIFF
--- a/nais/dev-sbs/serviceRedirects/frontendLogger.yaml
+++ b/nais/dev-sbs/serviceRedirects/frontendLogger.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontendlogger
+  namespace: personbruker
+spec:
+  type: ExternalName
+  externalName: frontendlogger.q1.svc.nais.local

--- a/nais/dev-sbs/serviceRedirects/veienTilArbeid.yaml
+++ b/nais/dev-sbs/serviceRedirects/veienTilArbeid.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: veientilarbeid
+  namespace: personbruker
+spec:
+  type: ExternalName
+  externalName: veientilarbeid.q1.svc.nais.local

--- a/nais/dev-sbs/serviceRedirects/veienTilArbeid.yaml
+++ b/nais/dev-sbs/serviceRedirects/veienTilArbeid.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: personbruker
 spec:
   type: ExternalName
-  externalName: veientilarbeid.q1.svc.nais.local
+  externalName: veientilarbeid.paw.svc.nais.local

--- a/nais/prod-sbs/serviceRedirects/frontendLogger.yaml
+++ b/nais/prod-sbs/serviceRedirects/frontendLogger.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontendlogger
+  namespace: personbruker
+spec:
+  type: ExternalName
+  externalName: frontendlogger.default.svc.nais.local

--- a/nais/prod-sbs/serviceRedirects/veienTilArbeid.yaml
+++ b/nais/prod-sbs/serviceRedirects/veienTilArbeid.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: veientilarbeid
+  namespace: personbruker
+spec:
+  type: ExternalName
+  externalName: veientilarbeid.default.svc.nais.local


### PR DESCRIPTION
Legger på service-redirects slik at DittNAV kan flyttes til namespace-et `personbruker`.

Dette må gjøres fordi PUS-Decorator peker mot `VTA` og `Frontendlogger` i samme namespace som DittNAV er deploy-et i. Dette fungerer kun hvis DittNAV, `VTA` og `Frontendlogger` ligger i samme namespace.

Denne fiksen legger til en redirect for både `VTA` og `Frontendlogger`, slik at hvis disse blir forsøk nådd fra personbruker-namespace-et så vil request-en bli sendt til namespace-et `default` i `prod` og `q1` i `dev`.

*Bruk*
Aktiveres: `kubectl apply -n personbruker -f <redirect>.yaml` mot riktig cluster.
Deaktivers: `kubectl delete service -n personbruker <frontendlogger/veientilarbeid>` mot riktig cluster.

PB-595. Flytte DittNAV til namespace-et personbruker i prod