### PR TITLE
Pb 578 ingresser

### DIFF
--- a/nais/dev-sbs/personbruker.json
+++ b/nais/dev-sbs/personbruker.json
@@ -1,6 +1,7 @@
 {
   "namespace": "personbruker",
   "ingresses": [
-    "https://www.dev.nav.no/person/dittnav"
+    "https://www.dev.nav.no/person/dittnav",
+    "https://dittnav.dev.nav.no/person/dittnav"
   ]
 }

--- a/nais/dev-sbs/personbruker.json
+++ b/nais/dev-sbs/personbruker.json
@@ -2,6 +2,6 @@
   "namespace": "personbruker",
   "ingresses": [
     "https://www.dev.nav.no/person/dittnav",
-    "https://dittnav.dev.nav.no/person/dittnav"
+    "https://dittnav.personbruker.nais.oera-q.local"
   ]
 }

--- a/nais/dev-sbs/personbruker.json
+++ b/nais/dev-sbs/personbruker.json
@@ -1,6 +1,6 @@
 {
   "namespace": "personbruker",
   "ingresses": [
-    "https://www.dev.nav.no/person/dittnav",
+    "https://www.dev.nav.no/person/dittnav"
   ]
 }

--- a/nais/dev-sbs/personbruker.json
+++ b/nais/dev-sbs/personbruker.json
@@ -2,6 +2,5 @@
   "namespace": "personbruker",
   "ingresses": [
     "https://www.dev.nav.no/person/dittnav",
-    "https://dittnav.personbruker.nais.oera-q.local"
   ]
 }

--- a/nais/dev-sbs/personbruker.json
+++ b/nais/dev-sbs/personbruker.json
@@ -2,6 +2,7 @@
   "namespace": "personbruker",
   "ingresses": [
     "https://www.dev.nav.no/person/dittnav",
+    "https://dittnav.dev.nav.no/person/dittnav",
     "https://dittnav.personbruker.nais.oera-q.local"
   ]
 }

--- a/nais/prod-sbs/default.json
+++ b/nais/prod-sbs/default.json
@@ -1,8 +1,0 @@
-{
-  "namespace": "personbruker",
-  "ingresses": [
-    "https://dittnav.nais.oera.no",
-    "https://www.nav.no/person/dittnav",
-    "https://tjenester.nav.no/person/dittnav"
-  ]
-}

--- a/nais/prod-sbs/default.json
+++ b/nais/prod-sbs/default.json
@@ -2,7 +2,6 @@
   "namespace": "personbruker",
   "ingresses": [
     "https://dittnav.nais.oera.no",
-    "https://dittnav.prod-sbs.nais.io",
     "https://www.nav.no/person/dittnav",
     "https://tjenester.nav.no/person/dittnav"
   ]

--- a/nais/prod-sbs/personbruker.json
+++ b/nais/prod-sbs/personbruker.json
@@ -2,7 +2,6 @@
   "namespace": "personbruker",
   "ingresses": [
     "https://dittnav.nais.oera.no",
-    "https://dittnav.prod-sbs.nais.io",
     "https://www.nav.no/person/dittnav",
     "https://tjenester.nav.no/person/dittnav"
   ]


### PR DESCRIPTION
La til dittnav.dev ingress, og fjernert nais.io ingresser i prod for å følge de nye retningslinjene.

oera-q ingressen beholdes enn så lenge, ettersom vi får `FORBIDDEN` hvis vi forsøker å nå selftest i dev på andre ingresser.