### PR TITLE
PB-629: Bedre plassering av meldekort

### DIFF
--- a/src/components/InfoMeldinger.js
+++ b/src/components/InfoMeldinger.js
@@ -19,9 +19,9 @@ const InfoMeldinger = () => {
   return (
     <section className="infomeldinger-list">
       <h1 className="skjermleser"><F id="dittnav.infomeldinger.varsler" /></h1>
+      <Meldekort />
       <Brukernotifikasjoner beskjeder={beskjeder} oppgaver={oppgaver} innbokser={innbokser} erAktiv />
       <InformasjonsMeldinger />
-      <Meldekort />
       <EtterregistreringMeldekort />
       <PaabegynteSoknader />
       <MinInnboks />


### PR DESCRIPTION
For å gjøre det lettere for brukere å sende meldekort så legges meldekortboksen øverst i listen av infomeldinger og ikke under brukernotifikasjoner.

PB-629: Bedre plassering av meldekort