### PR TITLE
Amplitude meldekort

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,25 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@amplitude/types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@amplitude/types/-/types-1.3.1.tgz",
+      "integrity": "sha512-YMANufwc3c0T7EGn6Nk8L2UwdLpZoqRFu+9f5EGrn2cReM2WdTZC1q2Dl9JLwZkdTE6mknjpOhW5c5ffC1n9LQ=="
+    },
+    "@amplitude/ua-parser-js": {
+      "version": "0.7.24",
+      "resolved": "https://registry.npmjs.org/@amplitude/ua-parser-js/-/ua-parser-js-0.7.24.tgz",
+      "integrity": "sha512-VbQuJymJ20WEw0HtI2np7EdC3NJGUWi8+Xdbc7uk8WfMIF308T0howpzkQ3JFMN7ejnrcSM/OyNGveeE3TP3TA=="
+    },
+    "@amplitude/utils": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@amplitude/utils/-/utils-1.3.1.tgz",
+      "integrity": "sha512-PzlQhR2wvr31Qxb7+Ua+EZi4SUn2VBBiur6MD4B/1oIxx4+0dFlecdzh1BL+XG+T86dMX46g3PMGyk2OStVDQw==",
+      "requires": {
+        "@amplitude/types": "^1.3.1",
+        "tslib": "^1.9.3"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -7047,6 +7066,29 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
+    "amplitude-js": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/amplitude-js/-/amplitude-js-7.4.1.tgz",
+      "integrity": "sha512-AiqYt9z0tzWBxcE0ILVDNOksXuPdZa4Jiak2VSWwBpgt+CUJ4jZzT3daGZPbw50o2/KnSIfMfAojcT7PpmKxLA==",
+      "requires": {
+        "@amplitude/ua-parser-js": "0.7.24",
+        "@amplitude/utils": "^1.0.5",
+        "blueimp-md5": "^2.10.0",
+        "query-string": "5"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        }
+      }
+    },
     "ansi-colors": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
@@ -8718,6 +8760,11 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
+    },
+    "blueimp-md5": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.18.0.tgz",
+      "integrity": "sha512-vE52okJvzsVWhcgUHOv+69OG3Mdg151xyn41aVQN/5W5S+S43qZhxECtYLAEHMSFWX6Mv5IZrzj3T5+JqXfj5Q=="
     },
     "bn.js": {
       "version": "4.11.8",
@@ -23081,8 +23128,7 @@
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-      "dev": true
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-length": {
       "version": "4.0.1",
@@ -24144,8 +24190,7 @@
     "tslib": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
-      "dev": true
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
     },
     "tsutils": {
       "version": "3.17.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@navikt/fnrvalidator": "1.1.3",
     "@navikt/nav-dekoratoren-moduler": "1.0.21",
     "@types/react-modal": "3.10.6",
+    "amplitude-js": "7.4.1",
     "classnames": "2.2.6",
     "core-js": "3.8.2",
     "cors": "2.8.5",

--- a/src/utils/amplitudeUtils.js
+++ b/src/utils/amplitudeUtils.js
@@ -1,0 +1,49 @@
+import amplitude from 'amplitude-js';
+import { Toggle } from '../constants';
+
+let initialized = false;
+
+const amplitudeUrl = 'amplitude.nav.no/collect';
+
+// PO Arbeid - prod
+const amplitudeProdKey = 'b0bccdd4dd75081606ef7bcab668a7ed';
+
+// PO Arbeid - test
+const amplitudeTestKey = '2f190e67f31d7e4719c5ff048ad3d3e6';
+
+function initAmplitude() {
+  if (Toggle.IS_TEST) {
+    return;
+  }
+  const erProduksjon = !Toggle.IS_DEV;
+  const amplitudeKey = erProduksjon ? amplitudeProdKey : amplitudeTestKey;
+
+  const config = {
+    apiEndpoint: amplitudeUrl,
+    saveEvents: true,
+    includeUtm: true,
+    includeReferrer: true,
+    trackingOptions: {
+      city: false,
+      ip_address: false,
+    },
+  };
+  amplitude.getInstance()
+    .init(amplitudeKey, undefined, config);
+  initialized = true;
+}
+
+initAmplitude();
+
+export function amplitudeLogger(name, values) {
+  if (!initialized) {
+    return;
+  }
+  amplitude.getInstance()
+    .logEvent(name, values);
+}
+
+export function loggAktivitet(aktivitet, data) {
+  const eventData = { ...data, aktivitet };
+  amplitudeLogger('dittnav.aktivitet', eventData);
+}

--- a/src/utils/googleAnalytics.js
+++ b/src/utils/googleAnalytics.js
@@ -1,4 +1,5 @@
 import ReactGA from 'react-ga';
+import { loggAktivitet } from './amplitudeUtils';
 
 const trackingId = 'UA-9127381-16';
 
@@ -36,13 +37,19 @@ export const initializeGoogleAnalytics = () => ReactGA.initialize(trackingId, {
   debug: false,
 });
 
-export const trackEvent = (category, action, label) => (
+export const trackEvent = (category, action, label) => {
   ReactGA.event({
     category,
     action,
     label,
-  })
-);
+  });
+
+  if (action === GoogleAnalyticsAction.MeldekortKlar
+    || action === GoogleAnalyticsAction.MeldekortVent) {
+    // Begrens mengden data sendt til Amplitude inntil vi har avklart behovet bedre
+    loggAktivitet(action);
+  }
+};
 
 export const removeFragment = (url) => {
   const fragmentPattern = '/#[a-z0-9]+/gi';


### PR DESCRIPTION
Hensikten med dette er å få et bedre bilde av brukeroppførsel i forbindelse med levering av meldekort: Hvordan kommer brukeren inn i Meldekort-løsningen?

Vi har i dag måling mot `Po Arbeid`-prosjektet i Amplitude for inngangene til Meldekort fra Veientilarbeid, og måling av aktivitet innenfor Meldekort-appen. Men vi har en hypotese om at mange benytter seg av denne infomeldingen om meldekort fra Ditt NAV, så vi ønsker nå et tall på dette også.

En «forenkling» av logikken kunne være å alltid sende all Google Analytics-data til Amplitude, men dette kan ende opp med å overstige maksimalt antall meldinger i Amplitude. Derfor er det lagt til en eksplisitt begrensning på de to handlingene vi er interessert i.