### PR TITLE
PB-635: Fjern dittnav fra google sin søkemotor

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex">
     <script type="application/javascript" src="appdynamics.js" charset='UTF-8'></script>
     <script src='https://jsagent.nav.no/adrum/adrum.js'></script>
     <script src='config.js'></script>


### PR DESCRIPTION
Fjerner DittNav fra google sin søkemotor, siden det gir en bedre brukeropplevelse om man går gjennom en landingsside først. Landingsidene for DittNav blir da:

- https://www.nav.no/no/person
- https://www.nav.no/no/ditt-nav

PB-635: Fjern DittNav fra google sin søkemotor