### PR TITLE
PB-789: Markere beskjeder (påbegynte) fra DigiSos som lest

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -129,6 +129,10 @@ export const postDone = (content) => (
   postJSON(`${Dittnav.DONE_URL}`, content)
 );
 
+export const postDigisosDone = (content) => (
+  postJSON(`${Dittnav.DIGISOS_DONE_URL}`, content)
+);
+
 export const postStatusoppdatering = (content) => (
   postJSON(`${TestProducer.STATUSOPPDATERING_URL}`, content)
 );

--- a/src/components/brukernotifikasjoner/Beskjed.js
+++ b/src/components/brukernotifikasjoner/Beskjed.js
@@ -5,13 +5,13 @@ import useSikkerhetsnivaa from '../../hooks/useSikkerhetsnivaa';
 import useStore from '../../hooks/useStore';
 import { transformTolokalDatoTid } from '../../utils/datoUtils';
 import PanelMedIkon from '../common/PanelMedIkon';
-import { postDigisosDone, postDone, tokenExpiresSoon } from '../../Api';
+import { postDigisosDone, postDone } from '../../Api';
 import IkonBeskjed from '../../assets/IkonBeskjed';
 import InnloggingsstatusType from '../../types/InnloggingsstatusType';
 import BeskjedType from '../../types/BeskjedType';
 import { GoogleAnalyticsAction, GoogleAnalyticsCategory, trackEvent } from '../../utils/googleAnalytics';
 
-const remove = (beskjed, removeBeskjed, visInnloggingsModal) => {
+const remove = (beskjed, removeBeskjed) => {
   if (beskjed.produsent === 'digiSos') {
     postDigisosDone({
       eventId: beskjed.eventId,
@@ -22,11 +22,8 @@ const remove = (beskjed, removeBeskjed, visInnloggingsModal) => {
   postDone({
     eventId: beskjed.eventId,
     uid: beskjed.uid,
-  }).then((headers) => {
-    if (tokenExpiresSoon(headers)) {
-      visInnloggingsModal();
-    }
   });
+
   removeBeskjed(beskjed);
 };
 

--- a/src/components/brukernotifikasjoner/Beskjed.js
+++ b/src/components/brukernotifikasjoner/Beskjed.js
@@ -5,13 +5,20 @@ import useSikkerhetsnivaa from '../../hooks/useSikkerhetsnivaa';
 import useStore from '../../hooks/useStore';
 import { transformTolokalDatoTid } from '../../utils/datoUtils';
 import PanelMedIkon from '../common/PanelMedIkon';
-import { postDone, tokenExpiresSoon } from '../../Api';
+import { postDigisosDone, postDone, tokenExpiresSoon } from '../../Api';
 import IkonBeskjed from '../../assets/IkonBeskjed';
 import InnloggingsstatusType from '../../types/InnloggingsstatusType';
 import BeskjedType from '../../types/BeskjedType';
 import { GoogleAnalyticsAction, GoogleAnalyticsCategory, trackEvent } from '../../utils/googleAnalytics';
 
 const remove = (beskjed, removeBeskjed, visInnloggingsModal) => {
+  if (beskjed.produsent === 'digiSos') {
+    postDigisosDone({
+      eventId: beskjed.eventId,
+      grupperingsId: beskjed.grupperingsId,
+      uid: beskjed.uid,
+    });
+  }
   postDone({
     eventId: beskjed.eventId,
     uid: beskjed.uid,

--- a/src/components/brukernotifikasjoner/Beskjed.js
+++ b/src/components/brukernotifikasjoner/Beskjed.js
@@ -16,7 +16,6 @@ const remove = (beskjed, removeBeskjed) => {
     postDigisosDone({
       eventId: beskjed.eventId,
       grupperingsId: beskjed.grupperingsId,
-      uid: beskjed.uid,
     });
   }
   postDone({

--- a/src/constants.js
+++ b/src/constants.js
@@ -33,6 +33,8 @@ export const Dittnav = Object.freeze({
     buildApiUrl('/innboks/inaktiv'),
   VARSLINGER_URL:
     buildNavNoUrl('/person/dittnav/varslinger'),
+  DIGISOS_DONE_URL:
+    buildApiUrl('/digisos/paabegynte/done'),
   DONE_URL:
     buildApiUrl('/produce/done'),
 });


### PR DESCRIPTION
* La til et nytt done endepunkt for beskjeder om påbegynte søknader fra digisos
* Fjerner visning av innloggingsmodal når man fjerner en beskjed siden timeout feilen bare skjer i legacy endepunktene

PB-789: Markere beskjeder (påbegynte) fra DigiSos som lest