### PR TITLE
Henter veientilarbeid fra dev-gcp

### DIFF
--- a/decorator.yaml
+++ b/decorator.yaml
@@ -1,6 +1,6 @@
 proxy:
   - contextPath: /person/dittnav/veientilarbeid
-    baseUrl: http://veientilarbeid
+    baseUrl: {{ VEIENTILARBEID_URL }}
     validateOidcToken: false
     requestRewrite: REMOVE_CONTEXT_PATH
     minSecurityLevel: 3

--- a/nais/dev-sbs/nais.yaml
+++ b/nais/dev-sbs/nais.yaml
@@ -36,3 +36,6 @@ spec:
     requests:
       cpu: 500m
       memory: 512Mi
+  env:
+    - name: VEIENTILARBEID_URL
+      value: "https://veientilarbeid.dev.nav.no"

--- a/nais/prod-sbs/nais.yaml
+++ b/nais/prod-sbs/nais.yaml
@@ -36,3 +36,6 @@ spec:
     requests:
       cpu: 500m
       memory: 512Mi
+  env:
+    - name: VEIENTILARBEID_URL
+      value: "https://veientilarbeid.nav.no"


### PR DESCRIPTION
Henter veientilarbeid fra en ingress istedenfor å bruke hostname i decorator.yaml. Dette gjør at vi nå henter veientilarbeid fra dev-gcp i dev-sbs. Med denne endringen kan PAW også migrere veientilarbeid fra prod-sbs til prod-gcp uten videre koordinering.