### PR TITLE
Skrivetilgang til appen slik at man får opprettet miljøvariabler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ COPY --from=navikt-common /dumb-init /dumb-init
 
 COPY run-script.sh /run-script.sh
 
-RUN chown -R 1069 /app
-RUN chmod -R u+rw /app
+RUN chown 1069 /app/config.js
+RUN chmod u+rw /app/config.js
 
 RUN chmod +x /entrypoint.sh /run-script.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ COPY --from=navikt-common /dumb-init /dumb-init
 
 COPY run-script.sh /run-script.sh
 
+RUN chown -R 1069 /app
+RUN chmod -R +rwu /app
+
 RUN chmod +x /entrypoint.sh /run-script.sh
 
 # Entrypoint-scriptet kopieres fra NAVs baseimage. Dette sørger for at init-scripts blir kjørt for å sette env-variablene som hentes fra Vault.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY --from=navikt-common /dumb-init /dumb-init
 COPY run-script.sh /run-script.sh
 
 RUN chown -R 1069 /app
-RUN chmod -R +rwu /app
+RUN chmod -R u+rw /app
 
 RUN chmod +x /entrypoint.sh /run-script.sh
 

--- a/nais/dev-sbs/nais.yaml
+++ b/nais/dev-sbs/nais.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: personbruker
   labels:
     team: personbruker
+  annotations:
+    nais.io/read-only-file-system: "false"
 spec:
   image: {{version}}
   ingresses:


### PR DESCRIPTION
En ny Nais policy i dev-sbs tar fra oss skrivetilgangen til filsystemet og gir oss denne feilen under deploy:

```
/run-script.sh: line 66: /app/config.js: Permission denied
/run-script.sh: line 57: /app/config.js: Permission denied
```

Denne PR-en fikser dette ved å bruke en opt-out annotation og gir appen (1069) skrivetilgang til mappen der config.js filen lages.